### PR TITLE
Feat/dynamic data spec

### DIFF
--- a/src/components/general/FieldArrayWrapper.tsx
+++ b/src/components/general/FieldArrayWrapper.tsx
@@ -15,6 +15,7 @@ interface Props {
   emptyObject: Record<string, string | Record<string, string | number> | Array<Record<string, string | number>>>;
   inputField: React.FC<InputFieldPropType>;
   color?: string;
+  setFieldValue?: (field: string, value: any, shouldValidate?: boolean | undefined) => void;
 }
 
 function isValueArray(value: boolean | string | ValueArray | undefined): value is ValueArray {
@@ -29,6 +30,7 @@ const FieldArrayWrapper: React.FC<Props> = ({
   inputField,
   emptyObject,
   color = 'red',
+  setFieldValue,
 }: Props) => {
   const myName = parentName ? `${parentName}.${name}` : name;
   return (
@@ -49,6 +51,7 @@ const FieldArrayWrapper: React.FC<Props> = ({
                   inputField={inputField}
                   arrayHelpers={arrayHelpers}
                   color={color}
+                  setFieldValue={setFieldValue}
                 />
               );
             });

--- a/src/components/general/LoadPreviousToggle.tsx
+++ b/src/components/general/LoadPreviousToggle.tsx
@@ -1,0 +1,123 @@
+import React from 'react';
+import CSS from 'csstype';
+import { Select, MenuItem, Checkbox, FormGroup, FormControlLabel } from '@material-ui/core';
+import { User } from '../../types/UserType';
+
+const emptyUser: User = {
+    firstName: '',
+    lastName: '',
+    mobilePhone: '',
+    email: '',
+    civilStatus: '',
+    address: {
+        street: '',
+        postalCode:'',
+        city: '',
+    },
+}
+const userOptions = Object.keys(emptyUser).reduce( (prev, key ) => {
+    if ( key !== 'address'){
+        return [`user.${key}`, ...prev];
+    }
+    return [...Object.keys(emptyUser.address).map( k => `user.address.${k}`), ...prev];
+  }, ['']); //add the empty string as an option, so that the user can choose to empty the select field in the form
+
+const inputFieldStyle: CSS.Properties = {
+    marginLeft: '7px',
+    marginTop: '5px',
+  };
+
+interface Props {
+    name: string;
+    label: string;
+    value: Record<string, any>;
+    setFieldValue?: (field: string, value: any, shouldValidate?: boolean | undefined) => void;
+}
+
+const LoadPreviousToggle: React.FC<Props> = ({name, label, value, setFieldValue}: Props) => {
+
+    const usingPreviousForm = (() => {
+      if (!value.loadPrevious) return false;
+      if (value.loadPrevious.length === 0) return false; 
+      if (value.loadPrevious[0].split('.')[0] === 'user') return false;
+      return true; 
+    }) ();
+
+    const userInfo = (() => {
+      if (!value.loadPrevious || value.loadPrevious.length === 0) return ''; 
+      if (usingPreviousForm) {
+        if (value.loadPrevious.length > 1) return value.loadPrevious[1];
+        return '';
+      }
+      return value.loadPrevious[0];
+    })();
+
+    const onToggle = () => {
+      if (usingPreviousForm){
+        if (setFieldValue) {
+          const [_, ...rest] = value.loadPrevious;
+          setFieldValue(name, rest);
+        }
+      } else {
+        if (setFieldValue) {
+          const id = value.id || value.key || value.title || '';
+          if(value?.loadPrevious){
+            setFieldValue(name, [id, ...value.loadPrevious]);
+          } else {
+            setFieldValue(name, [id]);
+          }
+        }
+      }
+    }
+
+    const onSelect = (event: React.ChangeEvent<{
+        name?: string | undefined;
+        value: unknown;}>) => {
+        const val = (event.target.value as string);
+        if(usingPreviousForm && setFieldValue){
+          const [first] = value.loadPrevious;
+          if(val !== '') { 
+            setFieldValue(name, [first, val]);
+          } else { 
+            setFieldValue(name, [first]);
+          }
+        } else if (val !== '' && setFieldValue) {
+          setFieldValue(name, [val]);
+        } else if(setFieldValue) {
+          setFieldValue(name, []);
+        }
+    }
+
+
+    return (
+        <>
+        <h4>Dynamic data loading</h4>
+        <FormGroup style={inputFieldStyle} row>
+            <FormControlLabel
+              control={
+                <Checkbox
+                  checked={usingPreviousForm}
+                  onChange={ (e) => { 
+                    onToggle(); 
+                    // onChange(e);
+                    }}
+                  name={name}
+                />
+              }
+              label={label}
+            />
+        </FormGroup>
+        <FormGroup style={inputFieldStyle} row>
+            <div style={{ paddingTop: '5px', marginRight: '10px' }}>Load from user info</div>
+            <Select name={name} onChange={onSelect} value={userInfo}>
+              {userOptions.map((choice) => (
+                    <MenuItem key={choice} value={choice}>
+                      {choice}
+                    </MenuItem>
+                  ))}
+            </Select>
+        </FormGroup>
+        </>);
+};
+
+export default LoadPreviousToggle;

--- a/src/components/general/MultipleInputField.tsx
+++ b/src/components/general/MultipleInputField.tsx
@@ -5,6 +5,7 @@ import FieldDescriptor from '../../types/FieldDescriptor';
 import FieldArrayWrapper from './FieldArrayWrapper';
 import FormContext from '../../contexts/FormContext';
 import { MultipleInputFieldPropType } from '../../types/PropTypes';
+import LoadPreviousToggle from './LoadPreviousToggle';
 
 const inputFieldStyle: CSS.Properties = {
   marginLeft: '7px',
@@ -17,6 +18,7 @@ const MultipleInputField: React.FC<MultipleInputFieldPropType> = ({
   name,
   value,
   fields,
+  setFieldValue,
   ...other
 }) => {
   const { forms } = useContext(FormContext);
@@ -41,7 +43,7 @@ const MultipleInputField: React.FC<MultipleInputFieldPropType> = ({
         return (
           <FormGroup style={inputFieldStyle} row>
             <div style={{ paddingTop: '5px', marginRight: '10px' }}>{field.label} </div>
-            <Select name={computedName} onChange={onChange} onBlur={onBlur} value={value[field.name]} {...other}>
+            <Select name={computedName} onChange={onChange} onBlur={onBlur} value={value[field.name] || field.initialValue} {...other}>
               {field.choices
                 ? field.choices.map((choice) => (
                     <MenuItem key={choice.name} value={choice.value}>
@@ -51,6 +53,14 @@ const MultipleInputField: React.FC<MultipleInputFieldPropType> = ({
                 : null}
             </Select>
           </FormGroup>
+        );
+      case 'loadPreviousToggle':
+        return (
+          <LoadPreviousToggle 
+            name={computedName} 
+            label={field.label} 
+            value={value || field.initialValue}
+            setFieldValue={setFieldValue} />
         );
       case 'checkbox':
         return (
@@ -78,6 +88,7 @@ const MultipleInputField: React.FC<MultipleInputFieldPropType> = ({
               inputField={field.inputField}
               emptyObject={{}}
               color="green"
+              setFieldValue={setFieldValue}
             />
           );
         }

--- a/src/components/general/SubContainer.tsx
+++ b/src/components/general/SubContainer.tsx
@@ -37,9 +37,10 @@ interface Props {
   inputField: React.FC<InputFieldPropType>;
   arrayHelpers: ArrayHelpers;
   itemValues?: Record<string, string | boolean | number>;
+  setFieldValue?: (field: string, value: any, shouldValidate?: boolean | undefined) => void;
 }
 
-const SubContainer: React.FC<Props> = ({ itemValues, name, currentIndex, inputField, arrayHelpers, color }: Props) => {
+const SubContainer: React.FC<Props> = ({ itemValues, name, currentIndex, inputField, arrayHelpers, color, ...other }: Props) => {
   const [collapsed, setCollapsed] = useState(true);
   const classes = useStyles();
 
@@ -47,7 +48,7 @@ const SubContainer: React.FC<Props> = ({ itemValues, name, currentIndex, inputFi
   if (!collapsed) {
     return (
       <Paper elevation={3} style={{ borderColor: color ? color : 'red' }} className={classes.subcontainer} key={name}>
-        <Field name={name} type="input" as={inputField} {...vals} />
+        <Field name={name} type="input" as={inputField} {...vals} {...other} />
 
         <div style={{ display: 'block', textAlign: 'right' }}>
           {currentIndex > 0 ? (

--- a/src/components/specific/FormBuilder.tsx
+++ b/src/components/specific/FormBuilder.tsx
@@ -22,7 +22,7 @@ const FormBuilder: React.FC<FormBuilderProps> = ({onSubmit, form}: FormBuilderPr
           onSubmit(form);
         }}
       >
-        {({ values }) => (
+        {({ values, setFieldValue }) => (
           <Form>
             <Typography variant="h3">{values.name !== '' ? values.name : 'Unnamed form'}</Typography>
             {id ? <pre>Form id: {id}</pre> : null}
@@ -37,6 +37,7 @@ const FormBuilder: React.FC<FormBuilderProps> = ({onSubmit, form}: FormBuilderPr
                 color="blue"
                 value={values}
                 inputField={StepField}
+                setFieldValue={setFieldValue}
                 emptyObject={{
                   title: '',
                   description: '',

--- a/src/components/specific/FormDataField.tsx
+++ b/src/components/specific/FormDataField.tsx
@@ -16,6 +16,7 @@ const formTypeInput: FieldDescriptor = {
   initialValue: '', 
   label:'Form Type (only for main forms)', 
   choices: [
+    { name: 'None', value: ''},
     { name: 'EKB löpande', value: 'EKB-recurring'},
     { name: 'EKB grund', value: 'EKB-new'},
   ]};

--- a/src/components/specific/Questions/EditableListInputField.tsx
+++ b/src/components/specific/Questions/EditableListInputField.tsx
@@ -16,6 +16,7 @@ const editableListFields: FieldDescriptor[] = [
   },
   { name: 'label', type: 'text', initialValue: '', label: 'Label' },
   { name: 'key', type: 'text', initialValue: '', label: 'Key' },
+  { name: 'loadPrevious', type: 'loadPreviousToggle', initialValue:'', label:'Load data from previous case?'},
 ];
 
 const EditableListInputField: React.FC<InputFieldPropType> = (props: InputFieldPropType) => {

--- a/src/components/specific/Questions/QuestionField.tsx
+++ b/src/components/specific/Questions/QuestionField.tsx
@@ -5,6 +5,7 @@ import EditableListInputField from './EditableListInputField';
 import SubstepListCategoryField from './SubstepList/SubstepListCategoryField';
 import SubstepListItemField from './SubstepList/SubstepListItemField';
 import { InputFieldPropType } from '../../../types/PropTypes';
+import LoadPreviousToggle from '../../general/LoadPreviousToggle';
 
 const questionFields: FieldDescriptor[] = [
   { name: 'label', type: 'text', initialValue: '', label: 'Label' },
@@ -29,8 +30,14 @@ const questionFields: FieldDescriptor[] = [
 ];
 
 const extraInputs: Record<string, FieldDescriptor[]> = {
-  text: [{ name: 'placeholder', type: 'text', initialValue: '', label: 'Placeholder' }],
-  number: [{ name: 'placeholder', type: 'text', initialValue: '', label: 'Placeholder' }],
+  text: [ 
+    { name: 'placeholder', type: 'text', initialValue: '', label: 'Placeholder' }, 
+    { name: 'loadPrevious', type: 'loadPreviousToggle', initialValue:'', label:'Load data from previous case?'}
+  ],
+  number: [
+    { name: 'placeholder', type: 'text', initialValue: '', label: 'Placeholder' }, 
+    { name: 'loadPrevious', type: 'loadPreviousToggle', initialValue:'', label:'Load data from previous case?'}
+  ],
   editableList: [
     { name: 'placeholder', type: 'text', initialValue: '', label: 'Placeholder' },
     { name: 'title', type: 'text', initialValue: '', label: 'Title' },
@@ -39,6 +46,7 @@ const extraInputs: Record<string, FieldDescriptor[]> = {
   checkbox: [
     { name: 'text', type: 'text', initialValue: '', label: 'Text' },
     { name: 'color', type: 'text', initialValue: 'light', label: 'Color' },
+    { name: 'loadPrevious', type: 'loadPreviousToggle', initialValue:'', label:'Load data from previous case?'},
   ],
   button: [{ name: 'text', type: 'text', initialValue: '', label: 'Button Text' }],
   substepList: [

--- a/src/components/specific/Questions/SubstepList/SubstepListItemField.tsx
+++ b/src/components/specific/Questions/SubstepList/SubstepListItemField.tsx
@@ -7,6 +7,7 @@ const fields: FieldDescriptor[] = [
   { name: 'title', type: 'text', initialValue: '', label: 'Title' },
   { name: 'category', type: 'text', initialValue: '', label: 'Category' },
   { name: 'formId', type: 'formSelect', initialValue: '', label: 'Subform' },
+  { name: 'loadPrevious', type: 'loadPreviousToggle', initialValue:'', label:'Load data from previous case?'},
 ];
 
 const SubstepListItemField: React.FC<InputFieldPropType> = (props: InputFieldPropType) => {

--- a/src/components/specific/Steps/StepField.tsx
+++ b/src/components/specific/Steps/StepField.tsx
@@ -7,7 +7,7 @@ import StepDataField from './StepDataField';
 import BannerField from './BannerField';
 import { InputFieldPropType } from '../../../types/PropTypes';
 
-const StepField: React.FC<InputFieldPropType> = ({ name, value }: InputFieldPropType) => {
+const StepField: React.FC<InputFieldPropType> = ({ name, value, ...other }: InputFieldPropType) => {
   return (
     <div>
       <h2>{value.title && value.title !== '' ? value.title : 'Unnamed step'}</h2>
@@ -27,6 +27,7 @@ const StepField: React.FC<InputFieldPropType> = ({ name, value }: InputFieldProp
           type: '',
           id: '',
         }}
+        {...other}
       />
 
       <FieldArrayWrapper
@@ -37,6 +38,7 @@ const StepField: React.FC<InputFieldPropType> = ({ name, value }: InputFieldProp
         inputField={ActionField}
         emptyObject={{ label: '', type: '' }}
         color="green"
+        {...other}
       />
     </div>
   );

--- a/src/types/FormTypes.ts
+++ b/src/types/FormTypes.ts
@@ -6,8 +6,24 @@ export interface Question {
   conditionalOn?: string;
   placeholder?: string;
   explainer?: string;
+  loadPrevious?: string[];  
+  items?: SubstepItem[];
+  inputs?: ListInput[];
 }
 
+export interface SubstepItem {
+  category: string;
+  title: string;
+  formId: string;
+  loadPrevious?: string[];
+}
+
+export interface ListInput {
+  type: 'text' | 'number';
+  key: string;
+  label: string;
+  loadPrevious?: string[];
+}
 export interface Action {
   type: string;
   label: string;

--- a/src/types/PropTypes.ts
+++ b/src/types/PropTypes.ts
@@ -7,6 +7,7 @@ export interface InputFieldPropType {
   type: string;
   onBlur: (e?: ChangeEvent<Element | { name?: string | undefined; value: unknown }>) => void;
   onChange: (e?: ChangeEvent<Element | { name?: string | undefined; value: unknown }>) => void;
+  setFieldValue?: (field: string, value: any, shouldValidate?: boolean | undefined) => void;
 }
 
 export interface MultipleInputFieldPropType {
@@ -16,4 +17,5 @@ export interface MultipleInputFieldPropType {
   fields: FieldDescriptor[];
   onBlur: (e?: ChangeEvent | ChangeEvent<{ name?: string | undefined; value: unknown }>) => void;
   onChange: (e?: ChangeEvent | ChangeEvent<{ name?: string | undefined; value: unknown }>) => void;
+  setFieldValue?: (field: string, value: any, shouldValidate?: boolean | undefined) => void;
 }

--- a/src/types/UserType.ts
+++ b/src/types/UserType.ts
@@ -1,0 +1,14 @@
+export interface User {
+    firstName: string;
+    lastName: string;
+    mobilePhone: string;
+    email: string;
+    civilStatus: string; //might not actually be a string...
+    address: Address;
+}
+
+export interface Address {
+    street: string;
+    postalCode: string;
+    city: string;
+}


### PR DESCRIPTION
Add support for specifying what data should be loaded dynamically from previous form and/or the user info object. This involved making a very specific input component with some semi-complicated logic, and configuring the questionField component so that it shows up in the right places, and it adds quite a bit of further complexity to the whole thing.

This will not work as intended in the app until the corresponding update is applied there, which is still work in progress as of this time. 