### PR TITLE
Feat/tags and field id select

### DIFF
--- a/src/components/general/MultipleInputField.tsx
+++ b/src/components/general/MultipleInputField.tsx
@@ -8,6 +8,7 @@ import { MultipleInputFieldPropType } from '../../types/PropTypes';
 import LoadPreviousToggle from './SmartInputs/LoadPreviousToggle';
 import NavigationButtonInput from '../specific/Questions/NavigationButton/NavigationButtonInput';
 import InputFieldSelect from './SmartInputs/InputFieldSelect';
+import TagsInput from './SmartInputs/TagsInput';
 
 const inputFieldStyle: CSS.Properties = {
   marginLeft: '7px',
@@ -133,6 +134,15 @@ const MultipleInputField: React.FC<MultipleInputFieldPropType> = ({
             name={computedName}
             label={field.label}
             value={value || field.initialValue}
+            setFieldValue={setFieldValue}
+          />
+        );
+      case 'tags':
+        return (
+          <TagsInput
+            name={computedName}
+            label={field.label}
+            value={value[field.name] || field.initialValue}
             setFieldValue={setFieldValue}
           />
         );

--- a/src/components/general/MultipleInputField.tsx
+++ b/src/components/general/MultipleInputField.tsx
@@ -5,8 +5,9 @@ import ColorPicker from 'material-ui-color-picker';
 import FieldDescriptor from '../../types/FieldDescriptor';
 import FieldArrayWrapper from './FieldArrayWrapper';
 import { MultipleInputFieldPropType } from '../../types/PropTypes';
-import LoadPreviousToggle from './LoadPreviousToggle';
+import LoadPreviousToggle from './SmartInputs/LoadPreviousToggle';
 import NavigationButtonInput from '../specific/Questions/NavigationButton/NavigationButtonInput';
+import InputFieldSelect from './SmartInputs/InputFieldSelect';
 
 const inputFieldStyle: CSS.Properties = {
   marginLeft: '7px',
@@ -125,6 +126,15 @@ const MultipleInputField: React.FC<MultipleInputFieldPropType> = ({
               {field && value && field.name && value[field.name] ? value[field.name] : field.initialValue}
             </p>
           </FormGroup>
+        );
+      case 'questionIdPicker':
+        return (
+          <InputFieldSelect
+            name={computedName}
+            label={field.label}
+            value={value || field.initialValue}
+            setFieldValue={setFieldValue}
+          />
         );
       default:
         return (

--- a/src/components/general/SmartInputs/InputFieldSelect.tsx
+++ b/src/components/general/SmartInputs/InputFieldSelect.tsx
@@ -1,0 +1,57 @@
+import React from 'react';
+import CSS from 'csstype';
+import { Select, MenuItem, FormGroup, FormControlLabel, Typography } from '@material-ui/core';
+import { useFormikContext } from 'formik';
+import { Form } from '../../../types/FormTypes';
+
+const inputFieldStyle: CSS.Properties = {
+  marginLeft: '7px',
+  marginTop: '5px',
+};
+
+interface Props {
+  name: string;
+  label: string;
+  value: Record<string, any>;
+  setFieldValue?: (field: string, value: any, shouldValidate?: boolean | undefined) => void;
+}
+
+const InputFieldSelect: React.FC<Props> = ({ name, label, value, setFieldValue }: Props) => {
+  const { values } = useFormikContext<Form>();
+  const onSelect = (
+    event: React.ChangeEvent<{
+      name?: string | undefined;
+      value: unknown;
+    }>,
+  ) => {
+    const val = event.target.value as string;
+    if (setFieldValue) {
+      setFieldValue(name, val);
+    }
+  };
+
+  if (values?.steps) {
+    const questionIds = values.steps.reduce((prev: string[], currentStep) => {
+      if (currentStep.questions) {
+        return [...prev, ...currentStep.questions.map((q) => q.id)];
+      }
+      return prev;
+    }, []);
+    return (
+      <FormGroup style={inputFieldStyle} row>
+        <div style={{ paddingTop: '5px', marginRight: '10px' }}> {label}</div>
+
+        <Select name={name} onChange={onSelect} value={value.id}>
+          {questionIds.map((qId) => (
+            <MenuItem key={qId} value={qId}>
+              {qId}
+            </MenuItem>
+          ))}
+        </Select>
+      </FormGroup>
+    );
+  }
+  return <Typography>No questions</Typography>;
+};
+
+export default InputFieldSelect;

--- a/src/components/general/SmartInputs/LoadPreviousToggle.tsx
+++ b/src/components/general/SmartInputs/LoadPreviousToggle.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import CSS from 'csstype';
 import { Select, MenuItem, Checkbox, FormGroup, FormControlLabel } from '@material-ui/core';
-import { User } from '../../types/UserType';
+import { User } from '../../../types/UserType';
 
 const emptyUser: User = {
   firstName: '',

--- a/src/components/general/SmartInputs/TagsInput.tsx
+++ b/src/components/general/SmartInputs/TagsInput.tsx
@@ -21,7 +21,6 @@ const TagsInput: React.FC<Props> = ({ name, label, value, setFieldValue }: Props
       setFieldValue(name, tags);
     }
   };
-  console.log('value', value);
   return <TextField fullWidth multiline rowsMax={3} name={name} onChange={onChange} value={value} label={label} />;
 };
 

--- a/src/components/general/SmartInputs/TagsInput.tsx
+++ b/src/components/general/SmartInputs/TagsInput.tsx
@@ -1,0 +1,28 @@
+import React from 'react';
+import { TextField } from '@material-ui/core';
+
+interface Props {
+  name: string;
+  label: string;
+  value: Record<string, any>;
+  setFieldValue?: (field: string, value: any, shouldValidate?: boolean | undefined) => void;
+}
+
+const TagsInput: React.FC<Props> = ({ name, label, value, setFieldValue }: Props) => {
+  const onChange = (
+    event: React.ChangeEvent<{
+      name?: string | undefined;
+      value: unknown;
+    }>,
+  ) => {
+    const val = event.target.value as string;
+    const tags = val.split(',').map((s) => s.trim());
+    if (setFieldValue) {
+      setFieldValue(name, tags);
+    }
+  };
+  console.log('value', value);
+  return <TextField fullWidth multiline rowsMax={3} name={name} onChange={onChange} value={value} label={label} />;
+};
+
+export default TagsInput;

--- a/src/components/specific/FormDataField.tsx
+++ b/src/components/specific/FormDataField.tsx
@@ -13,7 +13,7 @@ const formTypeInput: FieldDescriptor = {
   name: 'formType',
   type: 'select',
   initialValue: '',
-  label: 'Form Type (only for main forms)',
+  label: 'Form Type',
   choices: [
     { name: 'None', value: '' },
     { name: 'EKB löpande', value: 'EKB-recurring' },

--- a/src/components/specific/Questions/EditableListInputField.tsx
+++ b/src/components/specific/Questions/EditableListInputField.tsx
@@ -16,6 +16,7 @@ const editableListFields: FieldDescriptor[] = [
   },
   { name: 'label', type: 'text', initialValue: '', label: 'Label' },
   { name: 'key', type: 'text', initialValue: '', label: 'Key' },
+  { name: 'tags', type: 'tags', initialValue: '', label: 'Tags (enter as comma-separated list of words)' },
   { name: 'loadPrevious', type: 'loadPreviousToggle', initialValue: '', label: 'Load data from previous case?' },
 ];
 

--- a/src/components/specific/Questions/QuestionField.tsx
+++ b/src/components/specific/Questions/QuestionField.tsx
@@ -39,15 +39,15 @@ const questionFields: FieldDescriptor[] = [
 const extraInputs: Record<string, FieldDescriptor[]> = {
   text: [
     { name: 'placeholder', type: 'text', initialValue: '', label: 'Placeholder' },
-    { name: 'tags', type: 'tags', initialValue: '[]', label: 'Tags (enter as comma-separated list of words)' },
+    { name: 'tags', type: 'tags', initialValue: '', label: 'Tags (enter as comma-separated list of words)' },
     { name: 'loadPrevious', type: 'loadPreviousToggle', initialValue: '', label: 'Load data from previous case?' },
   ],
   number: [
     { name: 'placeholder', type: 'text', initialValue: '', label: 'Placeholder' },
-    { name: 'tags', type: 'tags', initialValue: '[]', label: 'Tags (enter as comma-separated list of words)' },
+    { name: 'tags', type: 'tags', initialValue: '', label: 'Tags (enter as comma-separated list of words)' },
     { name: 'loadPrevious', type: 'loadPreviousToggle', initialValue: '', label: 'Load data from previous case?' },
   ],
-  date: [{ name: 'tags', type: 'tags', initialValue: '[]', label: 'Tags (enter as comma-separated list of words)' }],
+  date: [{ name: 'tags', type: 'tags', initialValue: '', label: 'Tags (enter as comma-separated list of words)' }],
   editableList: [
     { name: 'placeholder', type: 'text', initialValue: '', label: 'Placeholder' },
     { name: 'title', type: 'text', initialValue: '', label: 'Title' },
@@ -57,7 +57,7 @@ const extraInputs: Record<string, FieldDescriptor[]> = {
     { name: 'text', type: 'text', initialValue: '', label: 'Text' },
     { name: 'color', type: 'text', initialValue: 'light', label: 'Color' },
     { name: 'inputHelp', type: 'text', initialValue: '', label: 'Value helper' },
-    { name: 'tags', type: 'tags', initialValue: '[]', label: 'Tags (enter as comma-separated list of words)' },
+    { name: 'tags', type: 'tags', initialValue: '', label: 'Tags (enter as comma-separated list of words)' },
     { name: 'loadPrevious', type: 'loadPreviousToggle', initialValue: '', label: 'Load data from previous case?' },
   ],
   avatarList: [

--- a/src/components/specific/Questions/QuestionField.tsx
+++ b/src/components/specific/Questions/QuestionField.tsx
@@ -39,12 +39,15 @@ const questionFields: FieldDescriptor[] = [
 const extraInputs: Record<string, FieldDescriptor[]> = {
   text: [
     { name: 'placeholder', type: 'text', initialValue: '', label: 'Placeholder' },
+    { name: 'tags', type: 'tags', initialValue: '[]', label: 'Tags (enter as comma-separated list of words)' },
     { name: 'loadPrevious', type: 'loadPreviousToggle', initialValue: '', label: 'Load data from previous case?' },
   ],
   number: [
     { name: 'placeholder', type: 'text', initialValue: '', label: 'Placeholder' },
+    { name: 'tags', type: 'tags', initialValue: '[]', label: 'Tags (enter as comma-separated list of words)' },
     { name: 'loadPrevious', type: 'loadPreviousToggle', initialValue: '', label: 'Load data from previous case?' },
   ],
+  date: [{ name: 'tags', type: 'tags', initialValue: '[]', label: 'Tags (enter as comma-separated list of words)' }],
   editableList: [
     { name: 'placeholder', type: 'text', initialValue: '', label: 'Placeholder' },
     { name: 'title', type: 'text', initialValue: '', label: 'Title' },
@@ -54,6 +57,7 @@ const extraInputs: Record<string, FieldDescriptor[]> = {
     { name: 'text', type: 'text', initialValue: '', label: 'Text' },
     { name: 'color', type: 'text', initialValue: 'light', label: 'Color' },
     { name: 'inputHelp', type: 'text', initialValue: '', label: 'Value helper' },
+    { name: 'tags', type: 'tags', initialValue: '[]', label: 'Tags (enter as comma-separated list of words)' },
     { name: 'loadPrevious', type: 'loadPreviousToggle', initialValue: '', label: 'Load data from previous case?' },
   ],
   avatarList: [

--- a/src/components/specific/Questions/RepeaterInputField.tsx
+++ b/src/components/specific/Questions/RepeaterInputField.tsx
@@ -6,6 +6,7 @@ import { InputFieldPropType } from '../../../types/PropTypes';
 const fields: FieldDescriptor[] = [
   { name: 'title', type: 'text', initialValue: '', label: 'Title' },
   { name: 'id', type: 'text', initialValue: '', label: 'Field id' },
+  { name: 'tags', type: 'tags', initialValue: '', label: 'Tags (enter as comma-separated list of words)' },
   {
     name: 'type',
     type: 'select',

--- a/src/components/specific/Questions/SummaryList/SummaryListItemField.tsx
+++ b/src/components/specific/Questions/SummaryList/SummaryListItemField.tsx
@@ -5,7 +5,7 @@ import { InputFieldPropType } from '../../../../types/PropTypes';
 
 const fields: FieldDescriptor[] = [
   { name: 'title', type: 'text', initialValue: '', label: 'Title' },
-  { name: 'id', type: 'text', initialValue: '', label: 'Field id' },
+  { name: 'id', type: 'questionIdPicker', initialValue: '', label: 'Field id' },
   { name: 'category', type: 'text', initialValue: '', label: 'Category' },
   {
     name: 'type',


### PR DESCRIPTION
Adds a special tags input, which takes a comma-separated text input, and stores it as an array of strings, which is used for storing tags for input fields. 

Also adds a fieldIdSelect component, which lets the user choose from existing field ids, instead of having to enter it as free text input. This is used when setting up what to show in a summary list. 