### PR TITLE
Add RadioGroup as an option for input types

### DIFF
--- a/src/components/general/SmartInputs/InputFieldSelect.tsx
+++ b/src/components/general/SmartInputs/InputFieldSelect.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import CSS from 'csstype';
-import { Select, MenuItem, FormGroup, FormControlLabel, Typography } from '@material-ui/core';
+import { Select, MenuItem, FormGroup, Typography } from '@material-ui/core';
 import { useFormikContext } from 'formik';
 import { Form } from '../../../types/FormTypes';
 

--- a/src/components/general/SubContainer.tsx
+++ b/src/components/general/SubContainer.tsx
@@ -104,7 +104,7 @@ const SubContainer: React.FC<Props> = ({
   }
 
   // Which fields to look for when generating a title to show when collapsed, in falling priority.
-  const prioritizedTitles = ['title', 'label', 'heading', 'description', 'text'];
+  const prioritizedTitles = ['title', 'label', 'heading', 'description', 'displayText', 'text'];
   const n = prioritizedTitles.reduce((foundTitle: string, current: string) => {
     if (foundTitle !== '') return foundTitle;
     if (itemValues && itemValues[current] && itemValues[current] !== '') return itemValues[current] as string;

--- a/src/components/specific/Questions/QuestionField.tsx
+++ b/src/components/specific/Questions/QuestionField.tsx
@@ -9,6 +9,7 @@ import RepeaterInputField from './RepeaterInputField';
 import CategoryField from './SummaryList/CategoryField';
 import QuestionTypeSelect from './QuestionTypeSelect';
 import { ValidationFieldTypes } from './ValidationRules';
+import RadioButtonChoice from './RadioButtonChoice';
 
 const questionFields: FieldDescriptor[] = [
   { name: 'label', type: 'text', initialValue: '', label: 'Label' },
@@ -38,9 +39,10 @@ const typeChoices: {
   { selectValue: 'navigationButtonGroup', displayName: 'Navigation button group', inputType: 'navigationButtonGroup' },
   { selectValue: 'summaryList', displayName: 'Summary List', inputType: 'summaryList' },
   { selectValue: 'repeaterField', displayName: 'Repeater Field', inputType: 'repeaterField' },
+  { selectValue: 'radioGroup', displayName: 'Radio buttons', inputType: 'radioGroup' },
 ];
 
-const extraInputs: Record<string, FieldDescriptor[]> = {
+const extraInputs: Partial<Record<InputType, FieldDescriptor[]>> = {
   text: [
     { name: 'placeholder', type: 'text', initialValue: '', label: 'Placeholder' },
     { name: 'tags', type: 'tags', initialValue: '', label: 'Tags (enter as comma-separated list of words)' },
@@ -93,11 +95,12 @@ const extraInputs: Record<string, FieldDescriptor[]> = {
     { name: 'loadPrevious', type: 'loadPreviousToggle', initialValue: '', label: 'Load data from previous case?' },
     { name: 'inputs', type: 'array', initialValue: '', label: 'Inputs (rows)', inputField: RepeaterInputField },
   ],
+  radioGroup: [{ name: 'choices', type: 'array', initialValue: '', label: 'Choices', inputField: RadioButtonChoice }],
 };
 
 const QuestionField: React.FC<InputFieldPropType> = (props: InputFieldPropType) => {
   const { value, name, setFieldValue } = props;
-  const extraInput = Object.keys(extraInputs).includes(value.type) && extraInputs[value.type];
+  const extraInput = Object.keys(extraInputs).includes(value.type) && extraInputs[value.type as InputType];
   return (
     <>
       <MultipleInputField fields={questionFields} {...props} />

--- a/src/components/specific/Questions/RadioButtonChoice.tsx
+++ b/src/components/specific/Questions/RadioButtonChoice.tsx
@@ -1,0 +1,15 @@
+import React from 'react';
+import FieldDescriptor from '../../../types/FieldDescriptor';
+import MultipleInputField from '../../general/MultipleInputField';
+import { InputFieldPropType } from '../../../types/PropTypes';
+
+const fields: FieldDescriptor[] = [
+  { name: 'displayText', type: 'text', initialValue: '', label: 'Display text' },
+  { name: 'value', type: 'text', initialValue: '', label: 'Value' },
+];
+
+const RadioButtonChoice: React.FC<InputFieldPropType> = (props: InputFieldPropType) => {
+  return <MultipleInputField fields={fields} {...props} />;
+};
+
+export default RadioButtonChoice;

--- a/src/types/FieldDescriptor.ts
+++ b/src/types/FieldDescriptor.ts
@@ -12,6 +12,7 @@ export type InputType =
   | 'avatarList'
   | 'navigationButton'
   | 'navigationButtonGroup'
+  | 'radioGroup'
   | 'summaryList'
   | 'repeaterField'
   | 'questionIdPicker'


### PR DESCRIPTION
Add RadioGroup as an option for input types. Adds the corresponding input component for the choices, and updates some types. 