### PR TITLE
preview: improve layout

### DIFF
--- a/src/preview/components/Card/Card.js
+++ b/src/preview/components/Card/Card.js
@@ -7,10 +7,10 @@ import { colorPalette } from '../../styles/palette';
 
 const Container = styled.div`
   margin-top: 12px;
+  margin-bottom: 12px;
   display: flex;
   flex-direction: column;
   border-radius: 10px;
-  margin-bottom: 16px;
   padding-left: 1px;
   padding-right: 1px;
   width: 90%;

--- a/src/preview/components/Footer/Footer.tsx
+++ b/src/preview/components/Footer/Footer.tsx
@@ -9,9 +9,6 @@ const ActionContainer = styled.div`
   display: flex;
   justify-content: flex-end;
   background-color: ${(props) => props.theme.colors.neutrals[5]};
-  position: absolute;
-  bottom: 0;
-  right: 0;
   width: 100%;
 `;
 const Flex = styled.div`

--- a/src/preview/step/Step.tsx
+++ b/src/preview/step/Step.tsx
@@ -10,15 +10,18 @@ import FormField from '../components/FormField/FormField';
 
 const StepContainer = styled.div`
   background: ${(props) => props.theme.colors.neutrals[7]};
+  display: inline-flex;
+  flex-direction: column;
+  justify-content: flex-start;
   flex: 1;
   width: 400px;
-  min-height: 800px;
+  padding-bottom: 0px;
   position: relative;
 `;
 
 const QuestionWrapper = styled.div`
   margin-left: 25px;
-  padding-bottom: 150px;
+  margin-bottom: 60px;
 `;
 
 interface Props {


### PR DESCRIPTION
Improve layout of the preview. Stop using the silly absolute positioning that was causing the last question to sometimes gets cutoff by the step footer, and start using flexbox more properly. Also fixes some margins to give a bit more space. 