### PR TITLE
help-popper: add a help popup box

### DIFF
--- a/src/components/general/MultipleInputField.tsx
+++ b/src/components/general/MultipleInputField.tsx
@@ -13,12 +13,18 @@ import TagsInput from './SmartInputs/TagsInput';
 import TextFieldWrapper from './TextFieldWrapper';
 import { useFormikContext } from 'formik';
 import { Form } from '../../types/FormTypes';
+import HelpPopper from './SmartInputs/HelpPopper';
 
 const inputFieldStyle: CSS.Properties = {
   marginLeft: '7px',
   marginTop: '5px',
+  width: '100%',
 };
-
+const row: CSS.Properties = {
+  display: 'inline-flex',
+  flexDirection: 'row',
+  width: '100%',
+};
 const MultipleInputField: React.FC<MultipleInputFieldPropType> = ({
   name,
   value,
@@ -37,11 +43,14 @@ const MultipleInputField: React.FC<MultipleInputFieldPropType> = ({
     switch (field.type) {
       case 'text':
         return (
-          <FastField
-            name={computedName}
-            as={TextFieldWrapper}
-            {...{ fullWidth: true, multiline: true, rowsMax: 3, label: field.label }}
-          />
+          <div style={row}>
+            <FastField
+              name={computedName}
+              as={TextFieldWrapper}
+              {...{ fullWidth: true, multiline: true, rowsMax: 3, label: field.label }}
+            />
+            {field.helpText && field.helpText !== '' && <HelpPopper style={{}} text={field.helpText} />}
+          </div>
         );
       case 'select':
         return (
@@ -56,6 +65,7 @@ const MultipleInputField: React.FC<MultipleInputFieldPropType> = ({
                   ))
                 : null}
             </FastField>
+            {field.helpText && field.helpText !== '' && <HelpPopper style={{}} text={field.helpText} />}
           </FormGroup>
         );
       case 'loadPreviousToggle':
@@ -65,11 +75,11 @@ const MultipleInputField: React.FC<MultipleInputFieldPropType> = ({
       case 'checkbox':
         return (
           <FormGroup style={inputFieldStyle} row>
-            {/* <Field as={Checkbox} name={computedName} checked={value?.showHelp} /> */}
             <FormControlLabel
               control={<FastField as={Checkbox} name={computedName} checked={value?.[field.name]} />}
               label={field.label}
             />
+            {field.helpText && field.helpText !== '' && <HelpPopper style={{}} text={field.helpText} />}
           </FormGroup>
         );
       case 'array':
@@ -113,9 +123,19 @@ const MultipleInputField: React.FC<MultipleInputFieldPropType> = ({
           </FormGroup>
         );
       case 'questionIdPicker':
-        return <InputFieldSelect name={computedName} label={field.label} />;
+        return (
+          <div style={row}>
+            <InputFieldSelect name={computedName} label={field.label} />
+            {field.helpText && field.helpText !== '' && <HelpPopper style={{}} text={field.helpText} />}
+          </div>
+        );
       case 'tags':
-        return <TagsInput name={computedName} label={field.label} value={value[field.name] || field.initialValue} />;
+        return (
+          <div style={row}>
+            <TagsInput name={computedName} label={field.label} value={value[field.name] || field.initialValue} />
+            {field.helpText && field.helpText !== '' && <HelpPopper style={{}} text={field.helpText} />}
+          </div>
+        );
       default:
         throw new Error(`Missing type ${field.type}`);
     }

--- a/src/components/general/SmartInputs/HelpPopper.tsx
+++ b/src/components/general/SmartInputs/HelpPopper.tsx
@@ -1,0 +1,52 @@
+import React from 'react';
+import { makeStyles, Theme, createStyles } from '@material-ui/core/styles';
+import Popper from '@material-ui/core/Popper';
+import Fade from '@material-ui/core/Fade';
+import IconButton from '@material-ui/core/IconButton';
+import { Help } from '@material-ui/icons';
+
+const useStyles = makeStyles((theme: Theme) =>
+  createStyles({
+    paper: {
+      padding: theme.spacing(1),
+      backgroundColor: theme.palette.background.paper,
+    },
+    popper: {
+      maxWidth: '300px',
+    },
+  }),
+);
+
+interface Props {
+  text: string;
+  style?: React.CSSProperties;
+}
+
+const HelpPopper: React.FC<Props> = ({ text, style }) => {
+  const classes = useStyles();
+  const [anchorEl, setAnchorEl] = React.useState<null | HTMLElement>(null);
+
+  const handleClick = (event: React.MouseEvent<HTMLElement>) => {
+    setAnchorEl(anchorEl ? null : event.currentTarget);
+  };
+
+  const open = Boolean(anchorEl);
+  const id = open ? 'transitions-popper' : undefined;
+
+  return (
+    <div style={style}>
+      <IconButton aria-describedby={id} type="button" onClick={handleClick}>
+        <Help />
+      </IconButton>
+      <Popper id={id} open={open} anchorEl={anchorEl} placement="right" transition className={classes.popper}>
+        {({ TransitionProps }) => (
+          <Fade {...TransitionProps} timeout={350}>
+            <div className={classes.paper}>{text}</div>
+          </Fade>
+        )}
+      </Popper>
+    </div>
+  );
+};
+
+export default HelpPopper;

--- a/src/components/general/SubContainer.tsx
+++ b/src/components/general/SubContainer.tsx
@@ -9,7 +9,7 @@ import { getPropertyFromDottedString } from '../../helpers/object';
 const useStyles = makeStyles((theme: Theme) =>
   createStyles({
     subcontainer: {
-      flexGrow: 1,
+      // flexGrow: 1,
       maxWidth: 752,
       margin: theme.spacing(4, 0, 2),
       backgroundColor: 'rgba(255, 255, 255, 0.10)',

--- a/src/components/specific/Questions/InputTypes/CardComponentField.tsx
+++ b/src/components/specific/Questions/InputTypes/CardComponentField.tsx
@@ -2,6 +2,7 @@ import React from 'react';
 import FieldDescriptor, { InputType } from '../../../../types/FieldDescriptor';
 import MultipleInputField from '../../../general/MultipleInputField';
 import { InputFieldPropType } from '../../../../types/PropTypes';
+import icons from '../../../../preview/helpers/Icons';
 
 const fields: FieldDescriptor[] = [
   {
@@ -27,7 +28,13 @@ const extraInputs: Record<string, FieldDescriptor[]> = {
     { name: 'italic', type: 'checkbox', initialValue: '', label: 'Italic' },
   ],
   image: [
-    { name: 'image', type: 'text', initialValue: '', label: 'Image filename' },
+    {
+      name: 'image',
+      type: 'text',
+      initialValue: '',
+      label: 'Image filename',
+      helpText: `Currently available images: ${Object.keys(icons).join(', ')}`,
+    },
     { name: 'circle', type: 'checkbox', initialValue: '', label: 'Round (otherwise square)' },
   ],
   button: [

--- a/src/components/specific/Questions/InputTypes/SummaryList/SummaryListItemField.tsx
+++ b/src/components/specific/Questions/InputTypes/SummaryList/SummaryListItemField.tsx
@@ -11,7 +11,14 @@ import CategorySelect from './CategorySelect';
 
 const fields: FieldDescriptor[] = [
   { name: 'title', type: 'text', initialValue: '', label: 'Title' },
-  { name: 'id', type: 'questionIdPicker', initialValue: '', label: 'Field id' },
+  {
+    name: 'id',
+    type: 'questionIdPicker',
+    initialValue: '',
+    label: 'Field id',
+    helpText:
+      'The field to show the value of. Can be a basic input field, or a editable list/repeater, in which case you also need to put in the input key.',
+  },
 ];
 
 const typeChoices: {

--- a/src/components/specific/Questions/QuestionField.tsx
+++ b/src/components/specific/Questions/QuestionField.tsx
@@ -16,11 +16,36 @@ import CardComponentField from './InputTypes/CardComponentField';
 
 const questionFields: FieldDescriptor[] = [
   { name: 'label', type: 'text', initialValue: '', label: 'Label' },
-  { name: 'labelHelp', type: 'text', initialValue: '', label: 'Helper' },
-  { name: 'description', type: 'text', initialValue: '', label: 'Description' },
-  { name: 'id', type: 'text', initialValue: '', label: 'Id' },
-  { name: 'conditionalOn', type: 'text', initialValue: '', label: 'Conditional on (field id)' },
-  { name: 'showHelp', type: 'checkbox', initialValue: '', label: 'Add help to the question?' },
+  {
+    name: 'description',
+    type: 'text',
+    initialValue: '',
+    label: 'Description',
+    helpText:
+      'Only to help editors of the form, not visible to the user. Add description if the function of the field is not clear.',
+  },
+  {
+    name: 'id',
+    type: 'text',
+    initialValue: '',
+    label: 'Id',
+    helpText: 'A unique id that identifies the input field. Careful when changing it!',
+  },
+  {
+    name: 'conditionalOn',
+    type: 'text',
+    initialValue: '',
+    label: 'Conditional on (field id)',
+    helpText: 'Show the question only if the conditional field is nonempty, or empty (put a ! infront of the id).',
+  },
+  {
+    name: 'showHelp',
+    type: 'checkbox',
+    initialValue: '',
+    label: 'Add help to the question?',
+    helpText:
+      'Adds a clickable help icon to the label or somewhere in the component, that opens a modal displaying the help text.',
+  },
 ];
 
 const typeChoices: {

--- a/src/components/specific/StepList/StepList.tsx
+++ b/src/components/specific/StepList/StepList.tsx
@@ -21,8 +21,8 @@ const useStyles = makeStyles((theme: Theme) =>
     },
     table: {
       display: 'table',
-      tableLayout: "fixed",
-      width: "100%",
+      tableLayout: 'fixed',
+      width: '100%',
     },
     row: {
       display: 'table-row',
@@ -36,7 +36,7 @@ const useStyles = makeStyles((theme: Theme) =>
       whiteSpace: 'nowrap',
       width: '75%',
       overflow: 'hidden',
-      textOverflow:'ellipsis',
+      textOverflow: 'ellipsis',
     },
   }),
 );
@@ -130,14 +130,20 @@ const StepList: React.FC<Props> = ({
     return (
       <div>
         <Paper
-          style={{ height: '34px', paddingLeft: '8px', paddingRight: '8px', borderBottomLeftRadius: '0px', borderTopLeftRadius: '0px' }}
+          style={{
+            height: '34px',
+            paddingLeft: '8px',
+            paddingRight: '8px',
+            borderBottomLeftRadius: '0px',
+            borderTopLeftRadius: '0px',
+          }}
           className={selectedStepId === item.id ? classes.selected : ''}
         >
           <div className={classes.table}>
             <div className={classes.row}>
               <span className={classes.col}>{collapseIcon}</span>
               <span onClick={toggleSelection(item)} className={classes.colCenter}>
-                <Typography style={{ fontSize: '12px', whiteSpace:'nowrap' }}>{item.text}</Typography>
+                <Typography style={{ fontSize: '12px', whiteSpace: 'nowrap' }}>{item.text}</Typography>
               </span>
               <div className={`${classes.col}`} style={{ width: 30 }}>
                 <IconButton color="primary" onClick={copyStep(item)}>

--- a/src/components/specific/Steps/ActionField.tsx
+++ b/src/components/specific/Steps/ActionField.tsx
@@ -10,7 +10,6 @@ const actionFields: FieldDescriptor[] = [
     initialValue: '',
     label: 'Type',
     choices: [
-      { name: 'Start', value: 'start' },
       { name: 'Next', value: 'next' },
       { name: 'Submit', value: 'submit' },
       { name: 'Sign', value: 'sign' },
@@ -19,7 +18,19 @@ const actionFields: FieldDescriptor[] = [
     ],
   },
   { name: 'label', type: 'text', initialValue: '', label: 'Label' },
-  { name: 'color', type: 'text', initialValue: '', label: 'Button color' },
+  {
+    name: 'color',
+    type: 'select',
+    initialValue: '',
+    label: 'Button color',
+    choices: [
+      { value: 'blue', name: 'Blue' },
+      { value: 'green', name: 'Green' },
+      { value: 'red', name: ' Red' },
+      { value: 'purple', name: 'Purple' },
+      { value: 'neutral', name: 'Neutral (gray)' },
+    ],
+  },
 ];
 
 const ActionField: React.FC<InputFieldPropType> = (props) => {

--- a/src/types/FieldDescriptor.ts
+++ b/src/types/FieldDescriptor.ts
@@ -32,4 +32,5 @@ export default interface FieldDescriptor {
   label: string;
   choices?: Record<string, string>[];
   inputField?: React.FC<InputFieldPropType>;
+  helpText?: string;
 }

--- a/src/types/PropTypes.ts
+++ b/src/types/PropTypes.ts
@@ -6,7 +6,7 @@ export interface InputFieldPropType {
   value: Record<string, any>;
 }
 
-export type MultipleInputFieldPropType = InputFieldPropType & {
+export interface MultipleInputFieldPropType extends InputFieldPropType {
   fields: FieldDescriptor[];
   validation?: ValidationRules;
-};
+}


### PR DESCRIPTION
Add a help popper, to show small explanations next to input fields. Also add a few such texts to various fields. 