### PR TITLE
added radio group to preview

### DIFF
--- a/src/components/general/MultipleInputField.tsx
+++ b/src/components/general/MultipleInputField.tsx
@@ -1,5 +1,5 @@
 import React, { useEffect } from 'react';
-import { FastField } from 'formik';
+import { FastField, useFormikContext } from 'formik';
 import CSS from 'csstype';
 import { Select, MenuItem, Checkbox, FormGroup, FormControlLabel } from '@material-ui/core';
 import ColorPicker from 'material-ui-color-picker';
@@ -11,7 +11,6 @@ import NavigationButtonInput from '../specific/Questions/InputTypes/NavigationBu
 import InputFieldSelect from './SmartInputs/InputFieldSelect';
 import TagsInput from './SmartInputs/TagsInput';
 import TextFieldWrapper from './TextFieldWrapper';
-import { useFormikContext } from 'formik';
 import { Form } from '../../types/FormTypes';
 import HelpPopper from './SmartInputs/HelpPopper';
 

--- a/src/preview/components/FormField/FormField.js
+++ b/src/preview/components/FormField/FormField.js
@@ -10,6 +10,7 @@ import EditableList from '../EditableList/EditableList';
 import SummaryList from '../SummaryList/SummaryList';
 import NavigationButtonGroup from '../NavigationButtonGroup/NavigationButtonGroup';
 import DynamicCardRenderer from '../Card/DynamicCardRenderer';
+import RadioGroup from '../RadioButton/RadioButton';
 
 const inputTypes = {
   text: {
@@ -41,6 +42,9 @@ const inputTypes = {
   },
   card: {
     component: DynamicCardRenderer,
+  },
+  radioGroup: {
+    component: RadioGroup,
   },
 };
 

--- a/src/preview/components/RadioButton/RadioButton.tsx
+++ b/src/preview/components/RadioButton/RadioButton.tsx
@@ -1,0 +1,19 @@
+import React from 'react';
+import { RadioGroup as RadioGroupMUI, FormControl, FormLabel, FormControlLabel, Radio } from '@material-ui/core';
+
+interface Props {
+    choices?: { displayText: string; value: string }[];
+    color?: string;
+}
+
+const RadioGroup: React.FC<Props> = ({ choices }) => 
+    (
+        <FormControl component="fieldset">
+            <RadioGroupMUI aria-label="radio group" name="preview radio group" >
+                {choices && choices.length > 0 && choices.map(choice => <FormControlLabel style={{color: 'black'}} value={choice.value} label={choice.displayText} control={<Radio />}/>)}
+            </RadioGroupMUI>
+        </FormControl>
+    );
+
+
+export default RadioGroup;


### PR DESCRIPTION
Add a simple preview of radio group inputs, without much styling. But it still shows the basic look and feel, and the different alternatives etc. 