### PR TITLE
Fix/navigation button group color select

### DIFF
--- a/src/components/specific/Questions/InputTypes/NavigationButton/NavigationButtonField.tsx
+++ b/src/components/specific/Questions/InputTypes/NavigationButton/NavigationButtonField.tsx
@@ -2,10 +2,17 @@ import React from 'react';
 import FieldDescriptor from '../../../../../types/FieldDescriptor';
 import MultipleInputField from '../../../../general/MultipleInputField';
 import { InputFieldPropType } from '../../../../../types/PropTypes';
+import { colorChoices } from '../../../../../helpers/colors';
 
 const fields: FieldDescriptor[] = [
   { name: 'text', type: 'text', initialValue: '', label: 'Button text' },
-  { name: 'color', type: 'text', initialValue: 'light', label: 'Color' },
+  {
+    name: 'color',
+    type: 'select',
+    initialValue: '',
+    label: 'Color theme',
+    choices: colorChoices,
+  },
   { name: 'iconName', type: 'text', initialValue: '', label: 'Icon name' },
   {
     name: 'navigationType',

--- a/src/components/specific/Questions/InputTypes/NavigationButton/NavigationButtonField.tsx
+++ b/src/components/specific/Questions/InputTypes/NavigationButton/NavigationButtonField.tsx
@@ -7,7 +7,7 @@ import { colorChoices } from '../../../../../helpers/colors';
 const fields: FieldDescriptor[] = [
   { name: 'text', type: 'text', initialValue: '', label: 'Button text' },
   {
-    name: 'color',
+    name: 'colorSchema',
     type: 'select',
     initialValue: '',
     label: 'Color theme',

--- a/src/components/specific/Questions/QuestionField.tsx
+++ b/src/components/specific/Questions/QuestionField.tsx
@@ -13,15 +13,7 @@ import RadioButtonChoice from './InputTypes/RadioButtonChoice';
 import SelectChoice from './InputTypes/SelectChoice';
 import HelpField from './HelpField';
 import CardComponentField from './InputTypes/CardComponentField';
-
-const colorChoices = [
-  { value: '', name: 'Inherit' },
-  { value: 'blue', name: 'Blue' },
-  { value: 'green', name: 'Green' },
-  { value: 'red', name: 'Red' },
-  { value: 'purple', name: 'Purple' },
-  { value: 'neutral', name: 'Neutral' },
-];
+import { colorChoices } from '../../../helpers/colors';
 
 const questionFields: FieldDescriptor[] = [
   { name: 'label', type: 'text', initialValue: '', label: 'Label' },

--- a/src/helpers/colors.ts
+++ b/src/helpers/colors.ts
@@ -1,0 +1,8 @@
+export const colorChoices = [
+  { value: '', name: 'Inherit' },
+  { value: 'blue', name: 'Blue' },
+  { value: 'green', name: 'Green' },
+  { value: 'red', name: 'Red' },
+  { value: 'purple', name: 'Purple' },
+  { value: 'neutral', name: 'Neutral' },
+];

--- a/src/preview/components/NavigationButtonGroup/NavigationButtonGroup.tsx
+++ b/src/preview/components/NavigationButtonGroup/NavigationButtonGroup.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 import styled from 'styled-components';
 import Button from '../Button/Button';
 import Text from '../Text/Text';
-import { getValidColorSchema } from '../../styles/themeHelpers';
+import { getValidColorSchema, PrimaryColor } from '../../styles/themeHelpers';
 
 const ScrollView = styled.div<{ horizontal?: boolean }>`
   display: inline-flex;
@@ -12,16 +12,21 @@ const ScrollView = styled.div<{ horizontal?: boolean }>`
 `;
 
 interface Props {
-  buttons?: { text: string; iconName?: string; color?: string }[];
+  buttons?: { text: string; iconName?: string; colorSchema?: PrimaryColor }[];
   horizontal?: boolean;
+  colorSchema: PrimaryColor;
 }
 
-const NavigationButtonGroup: React.FC<Props> = ({ buttons, horizontal }) => (
+const NavigationButtonGroup: React.FC<Props> = ({ buttons, horizontal, colorSchema }) => (
   <ScrollView horizontal={horizontal}>
     {buttons &&
       Array.isArray(buttons) &&
       buttons.map((button, index) => (
-        <Button key={`nav-button-${index}`} colorSchema={getValidColorSchema(button.color || '')} variant="outlined">
+        <Button
+          key={`nav-button-${index}`}
+          colorSchema={getValidColorSchema(button.colorSchema || colorSchema)}
+          variant="outlined"
+        >
           <Text>{button.text}</Text>
         </Button>
       ))}


### PR DESCRIPTION
Fix so that navigation button group uses the correct prop name, i.e. colorSchema instead of just color, and update the preview accordingly. Also move the colorChoice array to a helper, since we can use it from many places. 