### PR TITLE
feat(condition-input): smart input for boolean conditions

### DIFF
--- a/src/components/general/SmartInputs/ConditionInput.tsx
+++ b/src/components/general/SmartInputs/ConditionInput.tsx
@@ -1,0 +1,154 @@
+import React, { useState } from 'react';
+import CSS from 'csstype';
+import Autocomplete from '@material-ui/lab/Autocomplete';
+import { useFormikContext } from 'formik';
+import { Form } from '../../../types/FormTypes';
+import { Typography } from '@material-ui/core';
+import TextFieldWrapper from '../TextFieldWrapper';
+import HelpPopper from './HelpPopper';
+
+const row: CSS.Properties = {
+  display: 'inline-flex',
+  flexDirection: 'row',
+  justifyContent: 'space-between',
+  width: '100%',
+};
+
+type Operator = '!' | '&&' | '||';
+type Term =
+  | {
+      type: 'operator';
+      operator: Operator;
+    }
+  | {
+      type: 'expression';
+      expression: string;
+    };
+
+const grammar: {
+  previousSymbol: 'start' | 'expression' | Operator;
+  nextAllowed: (Operator | 'end' | 'expression')[];
+}[] = [
+  {
+    previousSymbol: 'start',
+    nextAllowed: ['expression', '!'],
+  },
+  {
+    previousSymbol: 'expression',
+    nextAllowed: ['&&', '||', 'end'],
+  },
+  {
+    previousSymbol: '!',
+    nextAllowed: ['expression'],
+  },
+  {
+    previousSymbol: '&&',
+    nextAllowed: ['expression', '!'],
+  },
+  {
+    previousSymbol: '||',
+    nextAllowed: ['expression', '!'],
+  },
+];
+const regex = /(!|&&|\|\|)/gm;
+function isOperator(s: string): s is Operator {
+  return ['!', '&&', '||'].includes(s);
+}
+
+const checkTerms = (terms: string[], allowedExpressions: string[]) => {
+  const paddedTerms = ['start', ...terms, 'end'];
+  const list = paddedTerms.map((s) => {
+    if (isOperator(s) || s === 'start' || s === 'end') return s;
+    if (allowedExpressions.includes(s)) return 'expression';
+    else return 'invalid term!';
+  });
+
+  let result: 'correct' | 'computing' | 'invalid' = 'computing';
+  for (const [i, el] of list.entries()) {
+    if (el === 'end' && result === 'computing') result = 'correct';
+    else if (el === 'invalid term!') result = 'invalid';
+    else {
+      const rule = grammar.find((r) => r.previousSymbol === el);
+      if (rule && !(rule.nextAllowed as string[]).includes(list[i + 1])) result = 'invalid';
+    }
+  }
+  return result;
+};
+
+interface Props {
+  name: string;
+  label: string;
+  value: Record<string, any>;
+  helpText?: string;
+}
+
+const ConditionInput: React.FC<Props> = ({ name, label, value, helpText }) => {
+  const { values, setFieldValue } = useFormikContext<Form>();
+
+  const lastPartOfName = name.split('.').reverse()[0];
+  console.log('value:', value, value[lastPartOfName]);
+  const initalValue = ((value?.[lastPartOfName] || '') as string)
+    .split(regex)
+    .map((s) => s.trim())
+    .filter((s) => s !== '');
+  const [expression, setExpression] = useState<string[]>(initalValue);
+  if (values?.steps) {
+    const questionIds = values.steps.reduce((prev: string[], currentStep) => {
+      if (currentStep.questions) {
+        return [...prev, ...currentStep.questions.map((q) => q.id)];
+      }
+      return prev;
+    }, []);
+
+    const onChange = (event: React.ChangeEvent<{}>, value: string[] | null) => {
+      setExpression(value || []);
+      if (setFieldValue) {
+        setFieldValue(name, value?.join(' '));
+      }
+    };
+    const valid = checkTerms(expression, questionIds);
+
+    const paddedExpression = ['start', ...expression, 'end'];
+    const lastTerm = paddedExpression[paddedExpression.length - 2];
+    let lastExp: 'start' | 'end' | 'expression' | Operator;
+    if (isOperator(lastTerm) || lastTerm === 'start' || lastTerm === 'end') lastExp = lastTerm;
+    else if (questionIds.includes(lastTerm)) lastExp = 'expression';
+
+    const nextAllowed = grammar.find((rule) => rule.previousSymbol === lastExp)?.nextAllowed;
+    let options: string[];
+    if (nextAllowed && nextAllowed?.includes('expression')) {
+      options = (nextAllowed.filter((s) => s !== 'end').filter((s) => s !== 'expression') as string[]).concat(
+        questionIds,
+      );
+    } else if (nextAllowed) {
+      options = nextAllowed.filter((s) => s !== 'end') as string[];
+    } else {
+      options = [];
+    }
+    return (
+      <div>
+        <Autocomplete
+          value={expression}
+          onInputChange={(event, newInputValue) => {
+            setExpression((old) => [...old, newInputValue]);
+          }}
+          multiple
+          getOptionSelected={() => false}
+          id="autocomplete"
+          options={options}
+          onChange={onChange}
+          renderInput={(params) => <TextFieldWrapper {...params} label={label} />}
+        />
+        <div style={row}>
+          <Typography>Expression: {expression.join(' ')}</Typography>
+          {helpText && helpText !== '' && <HelpPopper style={{}} text={helpText} />}
+        </div>
+        {valid === 'correct' && <Typography style={{ color: 'green' }}>Valid!</Typography>}
+        {valid === 'invalid' && <Typography color="secondary">Invalid!</Typography>}
+      </div>
+    );
+  }
+  return <Typography>No questions</Typography>;
+};
+
+export default ConditionInput;

--- a/src/components/specific/Questions/QuestionField.tsx
+++ b/src/components/specific/Questions/QuestionField.tsx
@@ -14,6 +14,7 @@ import SelectChoice from './InputTypes/SelectChoice';
 import HelpField from './HelpField';
 import CardComponentField from './InputTypes/CardComponentField';
 import { colorChoices } from '../../../helpers/colors';
+import ConditionInput from '../../general/SmartInputs/ConditionInput';
 
 const questionFields: FieldDescriptor[] = [
   { name: 'label', type: 'text', initialValue: '', label: 'Label' },
@@ -33,11 +34,11 @@ const questionFields: FieldDescriptor[] = [
     helpText: 'A unique id that identifies the input field. Careful when changing it!',
   },
   {
-    name: 'conditionalOn',
-    type: 'text',
+    name: 'hasCondition',
+    type: 'checkbox',
     initialValue: '',
-    label: 'Conditional on (field id)',
-    helpText: 'Show the question only if the conditional field is nonempty, or empty (put a ! infront of the id).',
+    label: 'Has Condition',
+    helpText: 'Show the question only if some condition is fulfilled.',
   },
   {
     name: 'showHelp',
@@ -182,20 +183,37 @@ const extraInputs: Partial<Record<InputType, FieldDescriptor[]>> = {
   ],
 };
 
+const conditionalHelpText = `Make the question show depending on values of other fields. Most basic usage is to put a fieldId here, then the question is shown only if that field is filled. Multiple fieldIds can also be entered, combining them with boolean logic operators ! (not), &&(and), || (or). For example 'field1 || field2' means that either field1 or field2 needs to be filled, while 'field1 && field2' means that both fields needs to have values, and so on. The order of operations is first !, then &&, finally ||. 
+    
+For lists and repeaters, empty means "no values", while filled means "at least one non-empty value". `;
+
 const QuestionField: React.FC<InputFieldPropType> = (props: InputFieldPropType) => {
   const { value, name } = props;
   const showHelp: boolean = value?.showHelp && value.showHelp === true;
+  const hasCondition: boolean = value?.hasCondition && value.hasCondition === true;
   const extraInput = Object.keys(extraInputs).includes(value.type) && extraInputs[value.type as InputType];
   return (
     <>
       <h3>General</h3>
       <MultipleInputField fields={questionFields} {...props} />
+      {hasCondition && (
+        <>
+          <h3>Condition</h3>
+          <ConditionInput
+            name={`${name}.conditionalOn`}
+            label={'Conditional on'}
+            value={value}
+            helpText={conditionalHelpText}
+          />
+        </>
+      )}
       {showHelp && (
         <>
           <h3>Help</h3>
           <HelpField name={`${name}.help`} value={value} />
         </>
       )}
+
       <h3>Specifics</h3>
       <QuestionTypeSelect name={name} value={value} label="Input Type" choices={typeChoices} />
       {extraInput && <MultipleInputField fields={extraInput} {...props} />}

--- a/src/components/specific/Steps/ActionField.tsx
+++ b/src/components/specific/Steps/ActionField.tsx
@@ -3,6 +3,8 @@ import FieldDescriptor from '../../../types/FieldDescriptor';
 import MultipleInputField from '../../general/MultipleInputField';
 import { InputFieldPropType } from '../../../types/PropTypes';
 
+import ConditionInput from '../../general/SmartInputs/ConditionInput';
+
 const actionFields: FieldDescriptor[] = [
   {
     name: 'type',
@@ -41,17 +43,9 @@ const actionFields: FieldDescriptor[] = [
   },
 ];
 
-const conditionInput: FieldDescriptor[] = [
-  {
-    name: 'conditionalOn',
-    type: 'text',
-    initialValue: '',
-    label: 'Conditional on',
-    helpText: `Make the action depend on values of another field. Most basic usage is to put a fieldId here, then the action is only allowed if that field is filled. Multiple fieldIds can also be entered, combining them with boolean logic operators ! (not), &&(and), || (or). For example 'field1 || field2' means that either field1 or field2 needs to be filled, while 'field1 && field2' means that both fields needs to have values, and so on. The order of operations is first !, then &&, finally ||. 
+const conditionalHelpText = `Make the action depend on values of another field. Most basic usage is to put a fieldId here, then the action is only allowed if that field is filled. Multiple fieldIds can also be entered, combining them with boolean logic operators ! (not), &&(and), || (or). For example 'field1 || field2' means that either field1 or field2 needs to be filled, while 'field1 && field2' means that both fields needs to have values, and so on. The order of operations is first !, then &&, finally ||. 
     
-    For lists and repeaters, empty means "no values", while filled means "at least one non-empty value". `,
-  },
-];
+For lists and repeaters, empty means "no values", while filled means "at least one non-empty value". `;
 
 const ActionField: React.FC<InputFieldPropType> = (props) => {
   const { value, name } = props;
@@ -59,7 +53,14 @@ const ActionField: React.FC<InputFieldPropType> = (props) => {
   return (
     <>
       <MultipleInputField fields={actionFields} {...props} />
-      {hasCondition && <MultipleInputField fields={conditionInput} {...props} />}
+      {hasCondition && (
+        <ConditionInput
+          name={`${name}.conditionalOn`}
+          label={'Conditional on'}
+          value={value}
+          helpText={conditionalHelpText}
+        />
+      )}
     </>
   );
 };

--- a/src/types/FormTypes.ts
+++ b/src/types/FormTypes.ts
@@ -5,6 +5,7 @@ export interface Question {
   type: string;
   id: string;
   description?: string;
+  hasCondition?: boolean;
   conditionalOn?: string;
   placeholder?: string;
   explainer?: string;


### PR DESCRIPTION
A first attempt at making a smart input for boolean conditions, that uses autocompletion to help writing valid conditions, and also validates the condition inline, showing an error if the condition is malformed. Also adds some help texts to try and explain how these conditions work and should be written. 

Uses the Material-Ui Autocomplete component, and a custom small validator.