### PR TITLE
fix(condition-input): fix keyboard input filtering

### DIFF
--- a/src/components/general/SmartInputs/ConditionInput.tsx
+++ b/src/components/general/SmartInputs/ConditionInput.tsx
@@ -129,9 +129,6 @@ const ConditionInput: React.FC<Props> = ({ name, label, value, helpText }) => {
       <div>
         <Autocomplete
           value={expression}
-          onInputChange={(event, newInputValue) => {
-            setExpression((old) => [...old, newInputValue]);
-          }}
           multiple
           getOptionSelected={() => false}
           id="autocomplete"


### PR DESCRIPTION
Fix keyboard input filtering the allowed terms correctly, and not creating invalid terms directly, by removing the onInputChange prop from the autocomplete component. 