### PR TITLE
feat(select-required): make it possible to make select input required

### DIFF
--- a/src/components/specific/Questions/QuestionField.tsx
+++ b/src/components/specific/Questions/QuestionField.tsx
@@ -71,7 +71,7 @@ const typeChoices: {
   { selectValue: 'summaryList', displayName: 'Summary List', inputType: 'summaryList' },
   { selectValue: 'repeaterField', displayName: 'Repeater Field', inputType: 'repeaterField' },
   { selectValue: 'radioGroup', displayName: 'Radio buttons', inputType: 'radioGroup' },
-  { selectValue: 'select', displayName: 'Select (dropdown menu)', inputType: 'select' },
+  { selectValue: 'select', displayName: 'Select (dropdown menu)', inputType: 'select', validationType: 'select' },
   { selectValue: 'card', displayName: 'Card (info text with action button)', inputType: 'card' },
   { selectValue: 'imageUploader', displayName: 'Image Uploader', inputType: 'imageUploader' },
 ];

--- a/src/components/specific/Questions/ValidationRules.ts
+++ b/src/components/specific/Questions/ValidationRules.ts
@@ -14,7 +14,8 @@ export type ValidationFieldTypes =
   | 'personalNumber'
   | 'phoneNumber'
   | 'postalCode'
-  | 'checkbox';
+  | 'checkbox'
+  | 'select';
 
 const ValidationFieldRules: Record<ValidationFieldTypes, ValidationObject> = {
   text: {
@@ -22,6 +23,10 @@ const ValidationFieldRules: Record<ValidationFieldTypes, ValidationObject> = {
     rules: [],
   },
   checkbox: {
+    isRequired: false,
+    rules: [],
+  },
+  select: {
     isRequired: false,
     rules: [],
   },


### PR DESCRIPTION
Add the option for setting the Select input as required, adding to it the validation rule isEmpty, similarly as is done for other inputs. 