### PR TITLE
fix(repeater-validation): add date and checkbox validation required option

### DIFF
--- a/src/components/specific/Questions/InputTypes/RepeaterInputField.tsx
+++ b/src/components/specific/Questions/InputTypes/RepeaterInputField.tsx
@@ -23,8 +23,8 @@ const typeChoices: {
   { selectValue: 'personalNumber', displayName: 'Personnummer', inputType: 'number', validationType: 'personalNumber' },
   { selectValue: 'phone', displayName: 'Telefonnummer', inputType: 'number', validationType: 'phoneNumber' },
   { selectValue: 'number', displayName: 'Number', inputType: 'number', validationType: 'number' },
-  { selectValue: 'date', displayName: 'Date', inputType: 'date' },
-  { selectValue: 'checkbox', displayName: 'Checkbox', inputType: 'checkbox' },
+  { selectValue: 'date', displayName: 'Date', inputType: 'date', validationType: 'date' },
+  { selectValue: 'checkbox', displayName: 'Checkbox', inputType: 'checkbox', validationType: 'checkbox' },
 ];
 
 const RepeaterInputField: React.FC<InputFieldPropType> = (props: InputFieldPropType) => {

--- a/src/components/specific/Questions/ValidationRules.ts
+++ b/src/components/specific/Questions/ValidationRules.ts
@@ -81,7 +81,7 @@ const ValidationFieldRules: Record<ValidationFieldTypes, ValidationObject> = {
     ],
   },
   phoneNumber: {
-    isRequired: true,
+    isRequired: false,
     rules: [
       {
         method: 'isMobilePhone',


### PR DESCRIPTION
Adds some validation options to repeater fields for date and checkbox, making it possible to set them to as required. Fixes a validation rule mistake for phoneNumber. 