### PR TITLE
feat: enable loadPrevious on hidden inputs

### DIFF
--- a/src/components/specific/Questions/QuestionField.tsx
+++ b/src/components/specific/Questions/QuestionField.tsx
@@ -90,6 +90,7 @@ const extraInputs: Partial<Record<InputType, FieldDescriptor[]>> = {
   hidden: [
     { name: 'value', type: 'text', initialValue: '', label: 'Value' },
     { name: 'tags', type: 'tags', initialValue: '', label: 'Tags (enter as comma-separated list of words)' },
+    { name: 'loadPrevious', type: 'loadPreviousToggle', initialValue: '', label: 'Load data from previous case?' },
   ],
   number: [
     { name: 'placeholder', type: 'text', initialValue: '', label: 'Placeholder' },


### PR DESCRIPTION
## Explain the changes you’ve made

Enabled hidden inputs to enable dynamic data loading.

## Explain why these changes are made

A hidden input is intended to be used to dynamically change a form (for showing co-applicant fields) by using a pre-populated value.

## Explain your solution

Added `loadPrevious` to `extraInputs` for `hidden` inputs, following the same format as for the others.

## How to test the changes?

1. Checkout this branch.
2. Verify that Dynamic data loading fields are visible for Hidden input fields.
3. (optional) Create a form with a Hidden input with a Dynamic data loading field set. Open the form in the app and verify that the Hidden input answer has a pre-populated value (e.g. by debugging or logging).

## Screenshots
<img width="283" alt="Screenshot 2021-06-03 at 15 16 36" src="https://user-images.githubusercontent.com/81566071/120651155-c251db80-c47e-11eb-95d6-a4860db825a7.png">
