### PR TITLE
feat: lägg till sorterings property till kategorier

### DIFF
--- a/src/components/specific/Questions/InputTypes/SummaryList/CategoryField.tsx
+++ b/src/components/specific/Questions/InputTypes/SummaryList/CategoryField.tsx
@@ -6,6 +6,7 @@ import { InputFieldPropType } from '../../../../../types/PropTypes';
 const fields: FieldDescriptor[] = [
   { name: 'category', type: 'text', initialValue: '', label: 'Category id' },
   { name: 'description', type: 'text', initialValue: '', label: 'Display name' },
+  { name: 'sortField', type: 'text', initialValue: '', label: 'Sort field' },
 ];
 
 const CategoryField: React.FC<InputFieldPropType> = (props: InputFieldPropType) => {


### PR DESCRIPTION
När en summarylist används, inordnas fält under kategorier. För att kunna visa repeaters
i en viss önskad ordning så behöver man tillföra ett fält som indikerar vilket fält som skall
användas som sorteringsnyckel. Appen kommer sedemera att använda detta värdet för att utföra sorteringen.