### PR TITLE
feat(pdfuploader): add tags

### DIFF
--- a/src/components/specific/Questions/QuestionField.tsx
+++ b/src/components/specific/Questions/QuestionField.tsx
@@ -244,6 +244,7 @@ const extraInputs: Partial<Record<InputType, FieldDescriptor[]>> = {
       initialValue: '',
       label: 'Max Number of documents (leave blank for no limit)',
     },
+    { name: 'tags', type: 'tags', initialValue: '', label: 'Tags (enter as comma-separated list of words)' },
   ],
   pdfViewer: [
     {


### PR DESCRIPTION
Added "tags" functionality to `pdfUploader`. Currently needed to give PDF fields the proper tags, so that they can be handled as attachments for VIVA.