### PR TITLE
feat: set style on referenced fields

### DIFF
--- a/src/components/specific/Questions/InputTypes/SummaryList/SummaryListItemField.tsx
+++ b/src/components/specific/Questions/InputTypes/SummaryList/SummaryListItemField.tsx
@@ -9,8 +9,8 @@ import { Form } from '../../../../../types/FormTypes';
 import { getPropertyFromDottedString } from '../../../../../helpers/object';
 import CategorySelect from './CategorySelect';
 
-const styleField: FieldDescriptor = {
-  name: 'styleField',
+const fieldStyle: FieldDescriptor = {
+  name: 'fieldStyle',
   type: 'select',
   initialValue: '',
   label: 'Field style',
@@ -71,7 +71,7 @@ const extraInputs: Record<string, FieldDescriptor[]> = {
       initialValue: '',
       label: 'Input id (should match the id of repeater input field id)',
     },
-    styleField,
+    fieldStyle,
   ],
   arrayNumber: [
     {
@@ -80,7 +80,7 @@ const extraInputs: Record<string, FieldDescriptor[]> = {
       initialValue: '',
       label: 'Input id (should match the id of repeater input field id)',
     },
-    styleField,
+    fieldStyle,
   ],
   arrayDate: [
     {
@@ -89,7 +89,7 @@ const extraInputs: Record<string, FieldDescriptor[]> = {
       initialValue: 'Default',
       label: 'Input id (should match the id of repeater input field id)',
     },
-    styleField,
+    fieldStyle,
   ],
   editableListText: [
     {

--- a/src/components/specific/Questions/InputTypes/SummaryList/SummaryListItemField.tsx
+++ b/src/components/specific/Questions/InputTypes/SummaryList/SummaryListItemField.tsx
@@ -9,6 +9,18 @@ import { Form } from '../../../../../types/FormTypes';
 import { getPropertyFromDottedString } from '../../../../../helpers/object';
 import CategorySelect from './CategorySelect';
 
+const styleField: FieldDescriptor = {
+  name: 'styleField',
+  type: 'select',
+  initialValue: '',
+  label: 'Field style',
+  choices: [
+    { name: 'Default', value: 'Default' },
+    { name: 'Grey', value: 'Grey' },
+    { name: 'Bold', value: 'Bold' },
+  ],
+};
+
 const fields: FieldDescriptor[] = [
   { name: 'title', type: 'text', initialValue: '', label: 'Title' },
   {
@@ -59,6 +71,7 @@ const extraInputs: Record<string, FieldDescriptor[]> = {
       initialValue: '',
       label: 'Input id (should match the id of repeater input field id)',
     },
+    styleField,
   ],
   arrayNumber: [
     {
@@ -67,14 +80,16 @@ const extraInputs: Record<string, FieldDescriptor[]> = {
       initialValue: '',
       label: 'Input id (should match the id of repeater input field id)',
     },
+    styleField,
   ],
   arrayDate: [
     {
       name: 'inputId',
       type: 'text',
-      initialValue: '',
+      initialValue: 'Default',
       label: 'Input id (should match the id of repeater input field id)',
     },
+    styleField,
   ],
   editableListText: [
     {


### PR DESCRIPTION
When creating a summarylist, An option is added to add a predefined style
to the field presentation. The style should be read and interpretaded by the app
when displaying the field