### PR TITLE
Add the ability to refer to applicant personal number

### DIFF
--- a/src/components/general/SmartInputs/LoadPreviousToggle.tsx
+++ b/src/components/general/SmartInputs/LoadPreviousToggle.tsx
@@ -11,6 +11,7 @@ const emptyUser: User = {
   mobilePhone: '',
   email: '',
   civilStatus: '',
+  personalNumber: '',
   address: {
     street: '',
     postalCode: '',

--- a/src/types/UserType.ts
+++ b/src/types/UserType.ts
@@ -5,6 +5,7 @@ export interface User {
   email: string;
   civilStatus: string; //might not actually be a string...
   address: Address;
+  personalNumber: string;
 }
 
 export interface Address {


### PR DESCRIPTION
This PR adds the ability to refer to the personalNumber of the applicant, in a similar fashion as other applicant properties, in accordance with #CU-2qa0nn9.

In order to get this to show up in the app (on grundansökan);

1. Add a new hidden field to the step with the firstName field, with the ID `hiddenPersonalNumber` and tag `personalNumber` and load from applicant info `applicant.personalNumber`
2. To the "about you" step, add a new field with the id `hiddenPersonalNumber` in the blank category.