### PR TITLE
Bug/initial position bug

### DIFF
--- a/src/components/specific/FormBuilder.tsx
+++ b/src/components/specific/FormBuilder.tsx
@@ -56,12 +56,24 @@ export interface FormBuilderProps {
   onSubmit: (form: FormType) => void;
 }
 
-const computeMatrix = (stepStruct: ListItem[], steps: Step[]): StepperActions[][] => {
-  const indices: Record<string, number> = steps.reduce((res: Record<string, number>, current, index) => {
-    res[current.id] = index;
+export const getStepstructureIds = (stepStructure: ListItem[]): string[] => {
+  const ids: string[] = [];
+
+  stepStructure.forEach((childStepStructure) => {
+    ids.push(childStepStructure.id);
+    ids.push(...getStepstructureIds(childStepStructure.children ?? []));
+  });
+
+  return ids;
+};
+
+export const computeMatrix = (stepStruct: ListItem[]): StepperActions[][] => {
+  const stepStuctureIds = getStepstructureIds(stepStruct);
+  const indices: Record<string, number> = stepStuctureIds.reduce((res: Record<string, number>, current, index) => {
+    res[current] = index;
     return res;
   }, {});
-  const emptyMatrix = [...Array(steps.length)].map((e) => Array(steps.length).fill('none'));
+  const emptyMatrix = [...Array(stepStuctureIds.length)].map((e) => Array(stepStuctureIds.length).fill('none'));
 
   const getDownIndices = (item: ListItem) => {
     if (item.children) {
@@ -215,7 +227,7 @@ const FormBuilder: React.FC<FormBuilderProps> = ({ onSubmit, form }: FormBuilder
         return (
           <Form
             onSubmit={(e) => {
-              const matrix = computeMatrix(stepStructure, values.steps || []);
+              const matrix = computeMatrix(stepStructure);
               values.connectivityMatrix = matrix;
               setValues(values);
               handleSubmit(e);

--- a/src/components/specific/FormBuilder.tsx
+++ b/src/components/specific/FormBuilder.tsx
@@ -170,6 +170,7 @@ const FormBuilder: React.FC<FormBuilderProps> = ({ onSubmit, form }: FormBuilder
       }}
     >
       {({ values, setFieldValue, handleSubmit, setValues }) => {
+        const { steps = [] } = values;
         return (
           <Form
             onSubmit={(e) => {
@@ -182,15 +183,15 @@ const FormBuilder: React.FC<FormBuilderProps> = ({ onSubmit, form }: FormBuilder
             <div className={classes.wrapper}>
               <div className={classes.column}>
                 <StepList
-                  steps={values.steps || []}
-                  deleteStep={deleteStep(values.steps || [], setFieldValue)}
-                  copyStep={copyStep(values.steps || [], setFieldValue)}
-                  addStep={addStep(values.steps || [], setFieldValue)}
+                  steps={steps}
                   selectedStepId={selectedStepId}
-                  selectStep={selectStep}
                   stepStructure={stepStructure}
                   setStepStructure={setStepStruct(setFieldValue)}
-                  onStepStructureOrderChange={handleStepStructureOrderChange(values.steps || [], setFieldValue)}
+                  selectStep={selectStep}
+                  deleteStep={deleteStep(steps, setFieldValue)}
+                  copyStep={copyStep(steps, setFieldValue)}
+                  addStep={addStep(steps, setFieldValue)}
+                  onStepStructureOrderChange={handleStepStructureOrderChange(steps, setFieldValue)}
                 />
               </div>
               <div className={classes.column}>{renderFormOrStep(values)}</div>

--- a/src/components/specific/FormBuilder.tsx
+++ b/src/components/specific/FormBuilder.tsx
@@ -17,7 +17,7 @@ export interface FormBuilderProps {
   steps: Step[];
   name: string;
   formId: string;
-  onSetFieldValue: (field: string, value: any) => void;
+  onSetFieldValue: (field: string, value: unknown) => void;
   onToggleShowJson: () => void;
 }
 

--- a/src/components/specific/FormBuilder.tsx
+++ b/src/components/specific/FormBuilder.tsx
@@ -30,7 +30,7 @@ const FormBuilder: React.FC<FormBuilderProps> = ({ onSubmit, form }: FormBuilder
     setFieldValue: (field: string, value: any, shouldValidate?: boolean | undefined) => void,
   ) => () => {
     const newStep: Step = {
-      title: '',
+      title: 'Unnamed',
       description: '',
       group: '',
       id: uuidv4(),
@@ -38,8 +38,11 @@ const FormBuilder: React.FC<FormBuilderProps> = ({ onSubmit, form }: FormBuilder
       colorSchema: 'blue',
     };
     const newSteps = [...steps, newStep];
+
+    const newStepStructureSteps = [...stepStructure, { id: newStep.id, text: newStep.title, group: uuidv4() }];
+
+    setStepStructure(newStepStructureSteps);
     setFieldValue('steps', newSteps);
-    return newStep;
   };
 
   const deleteStep = (

--- a/src/components/specific/FormBuilder.tsx
+++ b/src/components/specific/FormBuilder.tsx
@@ -35,11 +35,12 @@ const FormBuilder: React.FC<FormBuilderProps> = ({
 
   useEffect(() => {
     const recursiveReplace = (titles: Record<string, string>, item: ListItem): ListItem => {
+      const { id, group, children = [] } = item;
       return {
-        id: item.id,
-        text: titles[item.id] || 'Unnamed',
-        children: item?.children ? item.children.map((i) => recursiveReplace(titles, i)) : [],
-        group: item.group,
+        id,
+        text: titles[id] || 'Unnamed',
+        children: children.map((i) => recursiveReplace(titles, i)),
+        group,
       };
     };
 

--- a/src/components/specific/FormBuilder.tsx
+++ b/src/components/specific/FormBuilder.tsx
@@ -209,7 +209,6 @@ const FormBuilder: React.FC<FormBuilderProps> = ({ onSubmit, form }: FormBuilder
   };
 
   const setStepStruct = (setFieldValue: (field: string, value: any, shouldValidate?: boolean | undefined) => void) => (
-    steps: Step[],
     items: ListItem[] | ((prevState: ListItem[]) => ListItem[]),
   ) => {
     setStepStructure(items);

--- a/src/components/specific/FormBuilder.tsx
+++ b/src/components/specific/FormBuilder.tsx
@@ -110,8 +110,6 @@ const FormBuilder: React.FC<FormBuilderProps> = ({ onSubmit, form }: FormBuilder
 
     setFieldValue('steps', newSteps);
     setStepStructure(newStepStructure);
-
-    return newStep;
   };
 
   const handleStepStructureOrderChange = useCallback(

--- a/src/components/specific/FormBuilder.tsx
+++ b/src/components/specific/FormBuilder.tsx
@@ -1,7 +1,7 @@
 import React, { useState, useEffect } from 'react';
 import { Button, Paper, FormControlLabel, FormGroup, Switch, Typography } from '@material-ui/core';
 import { v4 as uuidv4 } from 'uuid';
-import { Step, ListItem } from '../../types/FormTypes';
+import type { Step, ListItem } from '../../types/FormTypes';
 import StepField from './Steps/StepField';
 import FormDataField from './FormDataField';
 import StepList from './StepList/StepList';

--- a/src/components/specific/FormBuilder.tsx
+++ b/src/components/specific/FormBuilder.tsx
@@ -7,7 +7,7 @@ import FormDataField from './FormDataField';
 import StepList from './StepList/StepList';
 import StepPreview from '../../preview/step/Step';
 
-import { getStepstructureIds } from './FormBuilderHelpers';
+import { matchStepStructureOrder, recursiveDelete } from './FormBuilderHelpers';
 
 import { useStyles } from './useFormBuilderStyles';
 
@@ -59,38 +59,6 @@ const FormBuilder: React.FC<FormBuilderProps> = ({
       onSetFieldValue('stepStructure', newStepStruct);
     }
   }, [steps]);
-
-  const matchStepStructureOrder = (stepStructures: ListItem[], steps: Step[]): Step[] => {
-    const stepStructureIds = getStepstructureIds(stepStructures);
-
-    const newStepsOrder: Step[] = [];
-
-    stepStructureIds.forEach((structureId: string) => {
-      const step = steps.find(({ id }) => structureId === id);
-
-      if (step !== undefined) {
-        newStepsOrder.push(step);
-      }
-    });
-    return newStepsOrder;
-  };
-
-  const recursiveDelete = (item: ListItem, stepId: string): ListItem[] => {
-    if (stepId === item.id) {
-      return item?.children || [];
-    }
-    if (item.children) {
-      return [
-        {
-          id: item.id,
-          group: item.group,
-          text: item.text,
-          children: item.children.flatMap((e) => recursiveDelete(e, stepId)),
-        },
-      ];
-    }
-    return [];
-  };
 
   const updateFormValues = (newStepStructure: ListItem[], newSteps: Step[]) => {
     const reorderedSteps = matchStepStructureOrder(newStepStructure, newSteps);

--- a/src/components/specific/FormBuilderHelpers.ts
+++ b/src/components/specific/FormBuilderHelpers.ts
@@ -1,4 +1,36 @@
-import { StepperActions, ListItem } from '../../types/FormTypes';
+import { StepperActions, ListItem, Step } from '../../types/FormTypes';
+
+export const recursiveDelete = (item: ListItem, stepId: string): ListItem[] => {
+  if (stepId === item.id) {
+    return item?.children || [];
+  }
+  if (item.children) {
+    return [
+      {
+        id: item.id,
+        group: item.group,
+        text: item.text,
+        children: item.children.flatMap((e) => recursiveDelete(e, stepId)),
+      },
+    ];
+  }
+  return [];
+};
+
+export const matchStepStructureOrder = (stepStructures: ListItem[], steps: Step[]): Step[] => {
+  const stepStructureIds = getStepstructureIds(stepStructures);
+
+  const newStepsOrder: Step[] = [];
+
+  stepStructureIds.forEach((structureId: string) => {
+    const step = steps.find(({ id }) => structureId === id);
+
+    if (step !== undefined) {
+      newStepsOrder.push(step);
+    }
+  });
+  return newStepsOrder;
+};
 
 export const getStepstructureIds = (stepStructure: ListItem[]): string[] => {
   const ids: string[] = [];

--- a/src/components/specific/FormBuilderHelpers.ts
+++ b/src/components/specific/FormBuilderHelpers.ts
@@ -49,7 +49,7 @@ export const computeMatrix = (stepStruct: ListItem[]): StepperActions[][] => {
     res[current] = index;
     return res;
   }, {});
-  const emptyMatrix = [...Array(stepStuctureIds.length)].map((e) => Array(stepStuctureIds.length).fill('none'));
+  const emptyMatrix = [...Array(stepStuctureIds.length)].map(() => Array(stepStuctureIds.length).fill('none'));
 
   const getDownIndices = (item: ListItem) => {
     if (item.children) {

--- a/src/components/specific/FormBuilderHelpers.ts
+++ b/src/components/specific/FormBuilderHelpers.ts
@@ -1,0 +1,77 @@
+import { StepperActions, ListItem } from '../../types/FormTypes';
+
+export const getStepstructureIds = (stepStructure: ListItem[]): string[] => {
+  const ids: string[] = [];
+
+  stepStructure.forEach((childStepStructure) => {
+    ids.push(childStepStructure.id);
+    ids.push(...getStepstructureIds(childStepStructure.children ?? []));
+  });
+
+  return ids;
+};
+
+export const computeMatrix = (stepStruct: ListItem[]): StepperActions[][] => {
+  const stepStuctureIds = getStepstructureIds(stepStruct);
+  const indices: Record<string, number> = stepStuctureIds.reduce((res: Record<string, number>, current, index) => {
+    res[current] = index;
+    return res;
+  }, {});
+  const emptyMatrix = [...Array(stepStuctureIds.length)].map((e) => Array(stepStuctureIds.length).fill('none'));
+
+  const getDownIndices = (item: ListItem) => {
+    if (item.children) {
+      const downIndices: number[] = [];
+      const children = item.children;
+      children.forEach((child, index) => {
+        if (index === 0 || child.group !== children[index - 1].group) {
+          downIndices.push(indices[child.id]);
+        }
+      });
+      return downIndices;
+    }
+    return [];
+  };
+  const getUpIndices = (item: ListItem) => {
+    if (item.children) return item.children.map((child) => indices[child.id]);
+    return [];
+  };
+
+  const recursiveBuild = (stepStruct: ListItem[], matrix: StepperActions[][], currentLevel: number) => {
+    stepStruct.forEach((currentStep, index) => {
+      const currentStepIndex = indices[currentStep.id];
+      if (currentLevel === 0) {
+        if (index > 0) {
+          const backIndex = indices[stepStruct[index - 1].id];
+          matrix[currentStepIndex][backIndex] = 'back';
+        }
+        if (index < stepStruct.length - 1) {
+          const nextIndex = indices[stepStruct[index + 1].id];
+          matrix[currentStepIndex][nextIndex] = 'next';
+        }
+      }
+      if (currentLevel > 0) {
+        if (index > 0 && currentStep.group === stepStruct[index - 1].group) {
+          const backIndex = indices[stepStruct[index - 1].id];
+          matrix[currentStepIndex][backIndex] = 'back';
+        }
+        if (index < stepStruct.length - 1 && currentStep.group === stepStruct[index + 1].group) {
+          const nextIndex = indices[stepStruct[index + 1].id];
+          matrix[currentStepIndex][nextIndex] = 'next';
+        }
+      }
+
+      getDownIndices(currentStep).forEach((n) => {
+        matrix[currentStepIndex][n] = 'down';
+      });
+      getUpIndices(currentStep).forEach((n) => {
+        matrix[n][currentStepIndex] = 'up';
+      });
+      if (currentStep.children) {
+        recursiveBuild(currentStep.children, matrix, currentLevel + 1);
+      }
+    });
+    return matrix;
+  };
+  return recursiveBuild(stepStruct, emptyMatrix, 0);
+};

--- a/src/components/specific/StepList/StepList.tsx
+++ b/src/components/specific/StepList/StepList.tsx
@@ -45,7 +45,7 @@ interface Props {
   count?: number;
   deleteStep: (id: string) => void;
   copyStep: (id: string) => Step;
-  addStep: () => Step;
+  addStep: () => void;
   selectedStepId: string;
   selectStep: (id: string) => void;
   stepStructure: ListItem[];
@@ -56,7 +56,7 @@ const StepList: React.FC<Props> = ({
   steps,
   deleteStep,
   copyStep: cpStep,
-  addStep: aStep,
+  addStep,
   selectedStepId,
   selectStep,
   stepStructure,
@@ -112,15 +112,6 @@ const StepList: React.FC<Props> = ({
     e.stopPropagation();
     const newStep = cpStep(item.id);
     const newSteps = [...stepStructure, { id: newStep?.id || '', text: newStep.title, group: uuidv4() }];
-    setStepStructure(newSteps);
-  };
-
-  const addStep = () => {
-    const newStep = aStep();
-    const newSteps = [
-      ...stepStructure,
-      { id: newStep?.id || '', text: newStep.title === '' ? 'Unnamed' : newStep.title, group: uuidv4() },
-    ];
     setStepStructure(newSteps);
   };
 

--- a/src/components/specific/StepList/StepList.tsx
+++ b/src/components/specific/StepList/StepList.tsx
@@ -148,9 +148,7 @@ const StepList: React.FC<Props> = ({
         renderItem={renderItem}
         maxDepth={3}
         renderCollapseIcon={renderCollapseIcon}
-        onChange={(items: ListItem[]) => {
-          onStepStructureOrderChange(items);
-        }}
+        onChange={onStepStructureOrderChange}
         collapsed
       />
       <Button className={classes.button} variant="contained" color="primary" onClick={addStep}>

--- a/src/components/specific/StepList/StepList.tsx
+++ b/src/components/specific/StepList/StepList.tsx
@@ -50,17 +50,19 @@ interface Props {
   selectStep: (id: string) => void;
   stepStructure: ListItem[];
   setStepStructure: (items: ListItem[] | ((prevState: ListItem[]) => ListItem[])) => void;
+  onStepStructureOrderChange: (items: ListItem[]) => void;
 }
 
 const StepList: React.FC<Props> = ({
   steps,
   deleteStep,
-  copyStep: cpStep,
+  copyStep,
   addStep,
   selectedStepId,
   selectStep,
   stepStructure,
   setStepStructure,
+  onStepStructureOrderChange,
 }: Props) => {
   const classes = useStyles();
 
@@ -90,31 +92,6 @@ const StepList: React.FC<Props> = ({
     }
   }, [steps]);
 
-  const delStep = (item: Item) => (e: React.MouseEvent) => {
-    e.stopPropagation();
-    selectStep('');
-
-    const recursiveDelete = (i: ListItem): ListItem[] => {
-      if (item.id === i.id) {
-        return i?.children || [];
-      }
-      if (i.children) {
-        return [{ id: i.id, group: i.group, text: i.text, children: i.children.flatMap((e) => recursiveDelete(e)) }];
-      }
-      return [];
-    };
-    const newStepStruct = stepStructure.flatMap((i) => recursiveDelete(i));
-    setStepStructure(newStepStruct);
-    deleteStep(item.id);
-  };
-
-  const copyStep = (item: Item) => (e: React.MouseEvent) => {
-    e.stopPropagation();
-    const newStep = cpStep(item.id);
-    const newSteps = [...stepStructure, { id: newStep?.id || '', text: newStep.title, group: uuidv4() }];
-    setStepStructure(newSteps);
-  };
-
   const toggleSelection = (item: Item) => () => {
     selectStep(item.id);
   };
@@ -138,12 +115,12 @@ const StepList: React.FC<Props> = ({
                 <Typography style={{ fontSize: '12px', whiteSpace: 'nowrap' }}>{item.text}</Typography>
               </span>
               <div className={`${classes.col}`} style={{ width: 30 }}>
-                <IconButton color="primary" onClick={copyStep(item)}>
+                <IconButton color="primary" onClick={() => copyStep(item.id)}>
                   <FileCopy fontSize="small" />
                 </IconButton>
               </div>
               <div className={`${classes.col}`} style={{ width: 30 }}>
-                <IconButton color="secondary" onClick={delStep(item)}>
+                <IconButton color="secondary" onClick={() => deleteStep(item.id)}>
                   <Clear fontSize="small" />
                 </IconButton>
               </div>
@@ -172,7 +149,7 @@ const StepList: React.FC<Props> = ({
         maxDepth={3}
         renderCollapseIcon={renderCollapseIcon}
         onChange={(items: ListItem[]) => {
-          setStepStructure(items);
+          onStepStructureOrderChange(items);
         }}
         collapsed
       />

--- a/src/components/specific/StepList/StepList.tsx
+++ b/src/components/specific/StepList/StepList.tsx
@@ -49,7 +49,7 @@ interface Props {
   selectedStepId: string;
   selectStep: (id: string) => void;
   stepStructure: ListItem[];
-  setStepStructure: (steps: Step[], items: ListItem[] | ((prevState: ListItem[]) => ListItem[])) => void;
+  setStepStructure: (items: ListItem[] | ((prevState: ListItem[]) => ListItem[])) => void;
 }
 
 const StepList: React.FC<Props> = ({
@@ -76,7 +76,6 @@ const StepList: React.FC<Props> = ({
 
     if (steps && stepStructure.length === 0) {
       setStepStructure(
-        steps,
         steps.map((step) => {
           return { id: step.id || '', text: step.title !== '' ? step.title : 'Unnamed', group: uuidv4() };
         }),
@@ -87,7 +86,7 @@ const StepList: React.FC<Props> = ({
         return acc;
       }, {});
       const newStepStruct = stepStructure.map((s) => recursiveReplace(titles, s));
-      setStepStructure(steps, newStepStruct);
+      setStepStructure(newStepStruct);
     }
   }, [steps]);
 
@@ -105,7 +104,7 @@ const StepList: React.FC<Props> = ({
       return [];
     };
     const newStepStruct = stepStructure.flatMap((i) => recursiveDelete(i));
-    setStepStructure(steps, newStepStruct);
+    setStepStructure(newStepStruct);
     deleteStep(item.id);
   };
 
@@ -113,16 +112,18 @@ const StepList: React.FC<Props> = ({
     e.stopPropagation();
     const newStep = cpStep(item.id);
     const newSteps = [...stepStructure, { id: newStep?.id || '', text: newStep.title, group: uuidv4() }];
-    setStepStructure([...steps, newStep], newSteps);
+    setStepStructure(newSteps);
   };
+
   const addStep = () => {
     const newStep = aStep();
     const newSteps = [
       ...stepStructure,
       { id: newStep?.id || '', text: newStep.title === '' ? 'Unnamed' : newStep.title, group: uuidv4() },
     ];
-    setStepStructure([...steps, newStep], newSteps);
+    setStepStructure(newSteps);
   };
+
   const toggleSelection = (item: Item) => () => {
     selectStep(item.id);
   };
@@ -180,7 +181,7 @@ const StepList: React.FC<Props> = ({
         maxDepth={3}
         renderCollapseIcon={renderCollapseIcon}
         onChange={(items: ListItem[]) => {
-          setStepStructure(steps || [], items);
+          setStepStructure(items);
         }}
         collapsed
       />

--- a/src/components/specific/StepList/StepList.tsx
+++ b/src/components/specific/StepList/StepList.tsx
@@ -44,7 +44,7 @@ interface Props {
   steps: Step[];
   count?: number;
   deleteStep: (id: string) => void;
-  copyStep: (id: string) => Step;
+  copyStep: (id: string) => void;
   addStep: () => void;
   selectedStepId: string;
   selectStep: (id: string) => void;

--- a/src/components/specific/StepList/StepList.tsx
+++ b/src/components/specific/StepList/StepList.tsx
@@ -1,6 +1,5 @@
 import React, { useEffect } from 'react';
 import { Step, ListItem } from '../../../types/FormTypes';
-// import Nestable, { Item } from 'react-nestable';
 import { Item } from 'react-nestable';
 import Nestable from '../../../nestable/Nestable';
 import { Button, createStyles, IconButton, makeStyles, Paper, Theme, Typography } from '@material-ui/core';

--- a/src/components/specific/StepList/StepList.tsx
+++ b/src/components/specific/StepList/StepList.tsx
@@ -1,10 +1,9 @@
-import React, { useEffect } from 'react';
-import { Step, ListItem } from '../../../types/FormTypes';
+import React from 'react';
+import { ListItem } from '../../../types/FormTypes';
 import { Item } from 'react-nestable';
 import Nestable from '../../../nestable/Nestable';
 import { Button, createStyles, IconButton, makeStyles, Paper, Theme, Typography } from '@material-ui/core';
 import { ExpandMore, ExpandLess, Clear, FileCopy } from '@material-ui/icons';
-import { v4 as uuidv4 } from 'uuid';
 
 const useStyles = makeStyles((theme: Theme) =>
   createStyles({
@@ -40,7 +39,6 @@ const useStyles = makeStyles((theme: Theme) =>
   }),
 );
 interface Props {
-  steps: Step[];
   count?: number;
   deleteStep: (id: string) => void;
   copyStep: (id: string) => void;
@@ -48,48 +46,19 @@ interface Props {
   selectedStepId: string;
   selectStep: (id: string) => void;
   stepStructure: ListItem[];
-  setStepStructure: (items: ListItem[] | ((prevState: ListItem[]) => ListItem[])) => void;
   onStepStructureOrderChange: (items: ListItem[]) => void;
 }
 
 const StepList: React.FC<Props> = ({
-  steps,
+  stepStructure,
+  selectedStepId,
   deleteStep,
   copyStep,
   addStep,
-  selectedStepId,
   selectStep,
-  stepStructure,
-  setStepStructure,
   onStepStructureOrderChange,
 }: Props) => {
   const classes = useStyles();
-
-  useEffect(() => {
-    const recursiveReplace = (titles: Record<string, string>, item: ListItem): ListItem => {
-      return {
-        id: item.id,
-        text: titles[item.id] || 'Unnamed',
-        children: item?.children ? item.children.map((i) => recursiveReplace(titles, i)) : [],
-        group: item.group,
-      };
-    };
-
-    if (steps && stepStructure.length === 0) {
-      setStepStructure(
-        steps.map((step) => {
-          return { id: step.id || '', text: step.title !== '' ? step.title : 'Unnamed', group: uuidv4() };
-        }),
-      );
-    } else {
-      const titles = steps.reduce((acc: Record<string, string>, curr: Step) => {
-        acc[curr.id] = curr.title === '' ? 'Unnamed' : curr.title;
-        return acc;
-      }, {});
-      const newStepStruct = stepStructure.map((s) => recursiveReplace(titles, s));
-      setStepStructure(newStepStruct);
-    }
-  }, [steps]);
 
   const toggleSelection = (item: Item) => () => {
     selectStep(item.id);

--- a/src/components/specific/test/FormBuilderHelpers.test.ts
+++ b/src/components/specific/test/FormBuilderHelpers.test.ts
@@ -1,25 +1,6 @@
 import { computeMatrix, getStepstructureIds } from '../FormBuilderHelpers';
 
-const stepStructure = [
-  {
-    children: [],
-    group: '2f200411-9ea6-44a6-b207-7ccdaa5606ba',
-    id: '5d29a0be-6b6a-444b-8f39-23dfe78b42a8',
-    text: 'Fråga 1',
-  },
-  {
-    children: [],
-    group: '808963dd-8a82-4e7f-9bd7-8449a7b9650a',
-    id: '2fd23656-7004-42e5-a68c-828659da574b',
-    text: 'Fråga 2',
-  },
-  {
-    children: [],
-    group: '495913a7-b365-4e2a-8552-3a11036d345e',
-    id: '652d65f2-1fd5-42a9-9442-ea05d8142ac2',
-    text: 'Fråga 3',
-  },
-];
+import { ListItem } from '../../../types/FormTypes';
 
 describe('computeMatrix', () => {
   const expectedMatrix = [
@@ -29,13 +10,34 @@ describe('computeMatrix', () => {
   ];
 
   it('returns the death matrix', () => {
+    const stepStructure = [
+      {
+        children: [],
+        group: '2f200411-9ea6-44a6-b207-7ccdaa5606ba',
+        id: '5d29a0be-6b6a-444b-8f39-23dfe78b42a8',
+        text: 'Fråga 1',
+      },
+      {
+        children: [],
+        group: '808963dd-8a82-4e7f-9bd7-8449a7b9650a',
+        id: '2fd23656-7004-42e5-a68c-828659da574b',
+        text: 'Fråga 2',
+      },
+      {
+        children: [],
+        group: '495913a7-b365-4e2a-8552-3a11036d345e',
+        id: '652d65f2-1fd5-42a9-9442-ea05d8142ac2',
+        text: 'Fråga 3',
+      },
+    ];
+
     const result = computeMatrix(stepStructure);
 
     expect(result).toEqual(expectedMatrix);
   });
 
-  it('returns the death matrix with changed stepstructure', () => {
-    const stepst = [
+  it('returns the death matrix with changed stepStructure order', () => {
+    const stepStructure = [
       {
         children: [],
         group: '808963dd-8a82-4e7f-9bd7-8449a7b9650a',
@@ -56,7 +58,7 @@ describe('computeMatrix', () => {
       },
     ];
 
-    const result = computeMatrix(stepst);
+    const result = computeMatrix(stepStructure);
 
     expect(result).toEqual(expectedMatrix);
   });
@@ -64,7 +66,7 @@ describe('computeMatrix', () => {
 
 describe('getStepstructureIds', () => {
   it('flattens ids from stepstructure', () => {
-    const stepst = [
+    const stepStructure = ([
       {
         children: [],
         id: '1',
@@ -77,14 +79,14 @@ describe('getStepstructureIds', () => {
         children: [],
         id: '3',
       },
-    ];
-    const result = getStepstructureIds(stepst);
+    ] as unknown) as ListItem[];
+    const result = getStepstructureIds(stepStructure);
 
     expect(result).toEqual(['1', '2', '3']);
   });
 
   it('flattens ids from stepstructure with children', () => {
-    const stepst = [
+    const stepStructure = ([
       {
         children: [
           {
@@ -117,9 +119,8 @@ describe('getStepstructureIds', () => {
         ],
         id: '5',
       },
-    ];
-    const result = getStepstructureIds(stepst);
-    console.log('RESULT: ', result);
+    ] as unknown) as ListItem[];
+    const result = getStepstructureIds(stepStructure);
 
     expect(result).toEqual(['1', '2', '3', '4', '5', '6', '7']);
   });

--- a/src/components/specific/test/FormBuilderHelpers.test.ts
+++ b/src/components/specific/test/FormBuilderHelpers.test.ts
@@ -1,4 +1,4 @@
-import { computeMatrix, getStepstructureIds } from '../FormBuilder';
+import { computeMatrix, getStepstructureIds } from '../FormBuilderHelpers';
 
 const stepStructure = [
   {

--- a/src/components/specific/test/FormBuilderHelpers.test.ts
+++ b/src/components/specific/test/FormBuilderHelpers.test.ts
@@ -1,6 +1,10 @@
-import { computeMatrix, getStepstructureIds } from '../FormBuilderHelpers';
+import { computeMatrix, getStepstructureIds, matchStepStructureOrder } from '../FormBuilderHelpers';
 
-import { ListItem } from '../../../types/FormTypes';
+import { ListItem, Step } from '../../../types/FormTypes';
+
+function makeSteps(ids: string[]) {
+  return ids.map((id) => ({ id }));
+}
 
 describe('computeMatrix', () => {
   const expectedMatrix = [
@@ -10,26 +14,23 @@ describe('computeMatrix', () => {
   ];
 
   it('returns the death matrix', () => {
-    const stepStructure = [
+    const stepStructure = ([
       {
         children: [],
-        group: '2f200411-9ea6-44a6-b207-7ccdaa5606ba',
         id: '5d29a0be-6b6a-444b-8f39-23dfe78b42a8',
         text: 'Fråga 1',
       },
       {
         children: [],
-        group: '808963dd-8a82-4e7f-9bd7-8449a7b9650a',
         id: '2fd23656-7004-42e5-a68c-828659da574b',
         text: 'Fråga 2',
       },
       {
         children: [],
-        group: '495913a7-b365-4e2a-8552-3a11036d345e',
         id: '652d65f2-1fd5-42a9-9442-ea05d8142ac2',
         text: 'Fråga 3',
       },
-    ];
+    ] as unknown) as ListItem[];
 
     const result = computeMatrix(stepStructure);
 
@@ -37,26 +38,23 @@ describe('computeMatrix', () => {
   });
 
   it('returns the death matrix with changed stepStructure order', () => {
-    const stepStructure = [
+    const stepStructure = ([
       {
         children: [],
-        group: '808963dd-8a82-4e7f-9bd7-8449a7b9650a',
         id: '2fd23656-7004-42e5-a68c-828659da574b',
         text: 'Fråga 2',
       },
       {
         children: [],
-        group: '2f200411-9ea6-44a6-b207-7ccdaa5606ba',
         id: '5d29a0be-6b6a-444b-8f39-23dfe78b42a8',
         text: 'Fråga 1',
       },
       {
         children: [],
-        group: '495913a7-b365-4e2a-8552-3a11036d345e',
         id: '652d65f2-1fd5-42a9-9442-ea05d8142ac2',
         text: 'Fråga 3',
       },
-    ];
+    ] as unknown) as ListItem[];
 
     const result = computeMatrix(stepStructure);
 
@@ -123,5 +121,61 @@ describe('getStepstructureIds', () => {
     const result = getStepstructureIds(stepStructure);
 
     expect(result).toEqual(['1', '2', '3', '4', '5', '6', '7']);
+  });
+});
+
+describe('matchStepStructureOrder', () => {
+  it('matches flattened stepStructure ids order in steps', () => {
+    const stepStructure = ([
+      {
+        children: [],
+        id: '1',
+      },
+      {
+        children: [],
+        id: '2',
+      },
+      {
+        children: [],
+        id: '3',
+      },
+    ] as unknown) as ListItem[];
+
+    const steps = makeSteps(['2', '3', '1']) as Step[];
+
+    const result = matchStepStructureOrder(stepStructure, steps);
+
+    expect(result).toEqual(makeSteps(['1', '2', '3']));
+  });
+
+  it('matches flattened stepStructure ids order (with children) in steps', () => {
+    const stepStructure = ([
+      {
+        children: [
+          {
+            id: '2',
+          },
+        ],
+        id: '1',
+      },
+      {
+        children: [],
+        id: '3',
+      },
+      {
+        children: [
+          {
+            id: '5',
+          },
+        ],
+        id: '4',
+      },
+    ] as unknown) as ListItem[];
+
+    const steps = makeSteps(['1', '4', '2', '3', '5']) as Step[];
+
+    const result = matchStepStructureOrder(stepStructure, steps);
+
+    expect(result).toEqual(makeSteps(['1', '2', '3', '4', '5']));
   });
 });

--- a/src/components/specific/test/Formbuilder.test.ts
+++ b/src/components/specific/test/Formbuilder.test.ts
@@ -1,0 +1,126 @@
+import { computeMatrix, getStepstructureIds } from '../FormBuilder';
+
+const stepStructure = [
+  {
+    children: [],
+    group: '2f200411-9ea6-44a6-b207-7ccdaa5606ba',
+    id: '5d29a0be-6b6a-444b-8f39-23dfe78b42a8',
+    text: 'Fråga 1',
+  },
+  {
+    children: [],
+    group: '808963dd-8a82-4e7f-9bd7-8449a7b9650a',
+    id: '2fd23656-7004-42e5-a68c-828659da574b',
+    text: 'Fråga 2',
+  },
+  {
+    children: [],
+    group: '495913a7-b365-4e2a-8552-3a11036d345e',
+    id: '652d65f2-1fd5-42a9-9442-ea05d8142ac2',
+    text: 'Fråga 3',
+  },
+];
+
+describe('computeMatrix', () => {
+  const expectedMatrix = [
+    ['none', 'next', 'none'],
+    ['back', 'none', 'next'],
+    ['none', 'back', 'none'],
+  ];
+
+  it('returns the death matrix', () => {
+    const result = computeMatrix(stepStructure);
+
+    expect(result).toEqual(expectedMatrix);
+  });
+
+  it('returns the death matrix with changed stepstructure', () => {
+    const stepst = [
+      {
+        children: [],
+        group: '808963dd-8a82-4e7f-9bd7-8449a7b9650a',
+        id: '2fd23656-7004-42e5-a68c-828659da574b',
+        text: 'Fråga 2',
+      },
+      {
+        children: [],
+        group: '2f200411-9ea6-44a6-b207-7ccdaa5606ba',
+        id: '5d29a0be-6b6a-444b-8f39-23dfe78b42a8',
+        text: 'Fråga 1',
+      },
+      {
+        children: [],
+        group: '495913a7-b365-4e2a-8552-3a11036d345e',
+        id: '652d65f2-1fd5-42a9-9442-ea05d8142ac2',
+        text: 'Fråga 3',
+      },
+    ];
+
+    const result = computeMatrix(stepst);
+
+    expect(result).toEqual(expectedMatrix);
+  });
+});
+
+describe('getStepstructureIds', () => {
+  it('flattens ids from stepstructure', () => {
+    const stepst = [
+      {
+        children: [],
+        id: '1',
+      },
+      {
+        children: [],
+        id: '2',
+      },
+      {
+        children: [],
+        id: '3',
+      },
+    ];
+    const result = getStepstructureIds(stepst);
+
+    expect(result).toEqual(['1', '2', '3']);
+  });
+
+  it('flattens ids from stepstructure with children', () => {
+    const stepst = [
+      {
+        children: [
+          {
+            id: '2',
+            children: [
+              {
+                id: '3',
+                children: [],
+              },
+            ],
+          },
+        ],
+        id: '1',
+      },
+      {
+        children: [],
+        id: '4',
+      },
+      {
+        children: [
+          {
+            id: '6',
+            children: [
+              {
+                id: '7',
+                children: [],
+              },
+            ],
+          },
+        ],
+        id: '5',
+      },
+    ];
+    const result = getStepstructureIds(stepst);
+    console.log('RESULT: ', result);
+
+    expect(result).toEqual(['1', '2', '3', '4', '5', '6', '7']);
+  });
+});

--- a/src/components/specific/useFormBuilderStyles.ts
+++ b/src/components/specific/useFormBuilderStyles.ts
@@ -1,0 +1,42 @@
+import { createStyles, makeStyles, Theme } from '@material-ui/core/styles';
+
+export const useStyles = makeStyles((theme: Theme) =>
+  createStyles({
+    root: {
+      '& > *': {
+        margin: theme.spacing(1),
+        width: '20ch',
+      },
+    },
+    subcontainer: {
+      flexGrow: 1,
+      maxWidth: 752,
+      margin: theme.spacing(4, 0, 2),
+      backgroundColor: 'rgba(255, 255, 255, 0.10)',
+      borderWidth: '1px',
+      borderStyle: 'solid',
+      boxShadow: '0 0 10px rgba(0, 0, 0, 0.3)',
+      padding: theme.spacing(1),
+      position: 'relative',
+      minHeight: '45px',
+    },
+    input: {
+      '& > *': {
+        width: '500px',
+      },
+    },
+    button: {
+      '& > *': {
+        margin: theme.spacing(1),
+        width: '2ch',
+      },
+    },
+    wrapper: {
+      display: 'grid',
+      gridTemplateColumns: '400px 800px 200px',
+    },
+    column: {
+      padding: theme.spacing(2),
+    },
+  }),
+);


### PR DESCRIPTION
**What was solved**
* Fixed a bug where the first step weren't shown when reordering the steps in form builder
* Removed duplicate state of stepStructure and only use formiks own state (source of truth)
* Moved formik to FormbuilderScreen to avoid having nested lambda functions 
* Made StepList a lot dumber (less logic)

**How was it solved**
Whenever a change is done in any step or stepStructure property, we reorder all steps to match the structure.

The ConnectivityMatrix (death matrix) is now calculated from a flattened stepStructure which have the exact order how steps appear.

Lift Formik to FormBuilderScreen which means that Formbuilder can remove its own copy of stepStructure state and only rely on Fromik:s internal state

StepList is now not responsible for setting correct steps and stepStructure data, this is lifted to FormBuilder

**Why was it solved in this way**
All steps are dependent on in which order questions are in the stepStructure property, so when steps are changed (moved, deleted, etc), the stepStructure is changed, but not the steps property. 

**How was it tested**
Tested on multiple forms and changed the order of when steps are. Also deleted som steps and added side steps.