### PR TITLE
fix(formbuilderscreen): improve performance when showing json

### DIFF
--- a/src/screens/FormBuilderScreen.tsx
+++ b/src/screens/FormBuilderScreen.tsx
@@ -10,6 +10,9 @@ import NotificationContext from '../contexts/NotificationsContext';
 
 import { computeMatrix } from '../components/specific/FormBuilderHelpers';
 
+const hiddenFormJsonProperties = ['connectivityMatrix'];
+const jsonCollapsedDepth = 3;
+
 const useStyles = makeStyles(() =>
   createStyles({
     inner: {
@@ -152,7 +155,13 @@ const FormBuilderScreen: React.FC = () => {
                 {showJSON && (
                   <div>
                     <h3>JSON Form data</h3>
-                    <ReactJson src={values} name="Form" theme="monokai" />
+                    <ReactJson
+                      src={values}
+                      name="Form"
+                      theme="monokai"
+                      collapsed={jsonCollapsedDepth}
+                      shouldCollapse={({ name }) => hiddenFormJsonProperties.includes(name as string)}
+                    />
                   </div>
                 )}
               </FormikForm>


### PR DESCRIPTION
**What was solved**
Improve performance when showing huge json in browser

**How was it solved**
Solved it by increase the depth to show and by collapse `connectivityMatrix` by default

**Why was it solved in this way**
the library used for showing the JSON have some properties to use to improve the performance

**How was it tested**
Tested it by show and hide the `grundansökan` JSON in the browser with increased performance